### PR TITLE
filter empty tests

### DIFF
--- a/actions/form/class.WizardForm.php
+++ b/actions/form/class.WizardForm.php
@@ -67,7 +67,13 @@ class taoDelivery_actions_form_WizardForm
         $formatElt->setDescription(__('Select the test you want to publish to the test-takers'));
         $testClass = new core_kernel_classes_Class(TAO_TEST_CLASS);
         $options = array();
+        $testService = taoTests_models_classes_TestsService::singleton();
         foreach ($testClass->getInstances(true) as $test) {
+            $testItems = $testService->getTestItems($test);
+            //Filter tests which has no items
+            if (empty($testItems)) { 
+                continue;
+            }
             $options[$test->getUri()] = $test->getLabel();
         } 
         


### PR DESCRIPTION
User should be not able to create test that has no items (so such items should not be represented in the selectbox).