### PR TITLE
Added storing deliveries executions with microseconds

### DIFF
--- a/models/classes/execution/class.KVDeliveryExecution.php
+++ b/models/classes/execution/class.KVDeliveryExecution.php
@@ -55,7 +55,7 @@ class taoDelivery_models_classes_execution_KVDeliveryExecution implements taoDel
             RDFS_LABEL => $assembly->getLabel(),
             PROPERTY_DELVIERYEXECUTION_DELIVERY => $assembly->getUri(),
             PROPERTY_DELVIERYEXECUTION_SUBJECT => $userId,
-            PROPERTY_DELVIERYEXECUTION_START => time(),
+            PROPERTY_DELVIERYEXECUTION_START => microtime(),
             PROPERTY_DELVIERYEXECUTION_STATUS => INSTANCE_DELIVERYEXEC_ACTIVE
         ));
         $de->save();
@@ -152,7 +152,7 @@ class taoDelivery_models_classes_execution_KVDeliveryExecution implements taoDel
         }
         $this->setData(PROPERTY_DELVIERYEXECUTION_STATUS, $state);
         if ($state == INSTANCE_DELIVERYEXEC_FINISHED) {
-            $this->setData(PROPERTY_DELVIERYEXECUTION_END, time());
+            $this->setData(PROPERTY_DELVIERYEXECUTION_END, microtime());
         }
         $this->save();
         $kvservice = new taoDelivery_models_classes_execution_KeyValueService(array(

--- a/models/classes/execution/class.OntologyDeliveryExecution.php
+++ b/models/classes/execution/class.OntologyDeliveryExecution.php
@@ -96,7 +96,7 @@ class taoDelivery_models_classes_execution_OntologyDeliveryExecution extends cor
         }
         $this->editPropertyValues($statusProp, $state);
         if ($state == INSTANCE_DELIVERYEXEC_FINISHED) {
-            $this->setPropertyValue(new core_kernel_classes_Property(PROPERTY_DELVIERYEXECUTION_END), time());
+            $this->setPropertyValue(new core_kernel_classes_Property(PROPERTY_DELVIERYEXECUTION_END), microtime());
         }
         return true;
     }

--- a/models/classes/execution/class.OntologyService.php
+++ b/models/classes/execution/class.OntologyService.php
@@ -95,7 +95,7 @@ class taoDelivery_models_classes_execution_OntologyService extends Configurable
             RDFS_LABEL                            => $assembly->getLabel(),
             PROPERTY_DELVIERYEXECUTION_DELIVERY   => $assembly,
             PROPERTY_DELVIERYEXECUTION_SUBJECT    => $userUri,
-            PROPERTY_DELVIERYEXECUTION_START      => time(),
+            PROPERTY_DELVIERYEXECUTION_START      => microtime(),
             PROPERTY_DELVIERYEXECUTION_STATUS     => INSTANCE_DELIVERYEXEC_ACTIVE        	
         ));
         return $this->getDeliveryExecution($execution);


### PR DESCRIPTION
Task: https://oat-sa.atlassian.net/browse/TAO-1106

Added formatting with support of milliseconds

Related to:
- https://github.com/oat-sa/tao-core/pull/500
- https://github.com/oat-sa/extension-tao-act/pull/50
- https://github.com/oat-sa/extension-tao-delivery/pull/96
- https://github.com/oat-sa/extension-tao-outcomeui/pull/39