### PR TITLE
enable to override return URL and set user label

### DIFF
--- a/actions/class.DeliveryServer.php
+++ b/actions/class.DeliveryServer.php
@@ -90,6 +90,8 @@ class taoDelivery_actions_DeliveryServer extends tao_actions_CommonModule
 		        $deliveryData[] = $this->getDeliverySettings($delivery, $user);
 		    }
 		}
+		$this->setData('returnUrl', $this->getReturnUrl());
+	    $this->setData('userLabel', common_session_SessionManager::getSession()->getUserLabel());
 		$this->setData('availableDeliveries', $deliveryData);
         $this->setData('showControls', $this->showControls());
 		$this->setData('processViewData', array());
@@ -131,6 +133,7 @@ class taoDelivery_actions_DeliveryServer extends tao_actions_CommonModule
 	    $runtime = taoDelivery_models_classes_DeliveryAssemblyService::singleton()->getRuntime($compiledDelivery);
 	    $this->setData('serviceApi', tao_helpers_ServiceJavascripts::getServiceApi($runtime, $deliveryExecution->getIdentifier()));
 
+		$this->setData('returnUrl', $this->getReturnUrl());
 	    $this->setData('userLabel', common_session_SessionManager::getSession()->getUserLabel());
 	    $this->setData('deliveryExecution', $deliveryExecution->getIdentifier());
 	    $this->setData('showControls', $this->showControls());

--- a/views/templates/DeliveryServer/blocks/header.tpl
+++ b/views/templates/DeliveryServer/blocks/header.tpl
@@ -11,7 +11,7 @@ use oat\tao\helpers\Layout;
 
             <ul class="clearfix plain">
                 <li data-control="home">
-                    <a id="home" href="<?= _url('index', 'DeliveryServer') ?>">
+                    <a id="home" href="<?=get_data('returnUrl')?>">
                         <span class="icon-home"></span>
                     </a>
                 </li>


### PR DESCRIPTION
 - use the `returnUrl` for the :house: action, so it can be overridden 
 - set the userLabel also on the delivery selection page