### PR TITLE
Fixes PARADS-5033 - AssembledDeliveryOrigin should be in taoDelivery/…

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -36,6 +36,7 @@ $todefine = array(
     'PROPERTY_COMPILEDDELIVERY_TIME'       => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDeliveryCompilationTime',
     'PROPERTY_COMPILEDDELIVERY_RUNTIME'    => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDeliveryRuntime',
     'PROPERTY_COMPILEDDELIVERY_DIRECTORY'  => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDeliveryCompilationDirectory',
+	'PROPERTY_ORIGIN'                      => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDeliveryOrigin',
 
     'CLASS_DELVIERYEXECUTION'              => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecution',
     'PROPERTY_DELVIERYEXECUTION_DELIVERY'  => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionDelivery',

--- a/models/classes/class.DeliveryAssemblyService.php
+++ b/models/classes/class.DeliveryAssemblyService.php
@@ -28,8 +28,6 @@
 class taoDelivery_models_classes_DeliveryAssemblyService extends tao_models_classes_ClassService
 {
     
-    const PROPERTY_ORIGIN = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDeliveryOrigin';
-
     /**
      * (non-PHPdoc)
      * 
@@ -94,7 +92,7 @@ class taoDelivery_models_classes_DeliveryAssemblyService extends tao_models_clas
     }
     
     public function getOrigin( core_kernel_classes_Resource $assembly) {
-        return (string)$assembly->getUniquePropertyValue(new core_kernel_classes_Property(self::PROPERTY_ORIGIN));
+        return (string)$assembly->getUniquePropertyValue(new core_kernel_classes_Property(PROPERTY_ORIGIN));
     }
 
 }

--- a/models/classes/class.SimpleDeliveryFactory.php
+++ b/models/classes/class.SimpleDeliveryFactory.php
@@ -53,7 +53,7 @@ class taoDelivery_models_classes_SimpleDeliveryFactory
             $properties = array(
                 RDFS_LABEL => $label,
                 PROPERTY_COMPILEDDELIVERY_DIRECTORY => $storage->getSpawnedDirectoryIds(),
-                taoDelivery_models_classes_DeliveryAssemblyService::PROPERTY_ORIGIN => $test
+                PROPERTY_ORIGIN => $test
             );
         
             $compilationInstance = taoDelivery_models_classes_DeliveryAssemblyService::singleton()->createAssemblyFromServiceCall($deliveryClass, $serviceCall, $properties);


### PR DESCRIPTION
Pull request for ticket PARADS-5033 - AssembledDeliveryOrigin should be in taoDelivery/includes/constant.php:
List of files affected:
1- taoDelivery\includes\constants.php
2- taoDelivery\models\classes\class.DeliveryAssemblyService.php
3- taoDelivery\models\classes\class.SimpleDeliveryFactory.php