### PR TITLE
Tao 1775 pause test

### DIFF
--- a/views/js/controller/runtime/deliveryExecution.js
+++ b/views/js/controller/runtime/deliveryExecution.js
@@ -96,7 +96,7 @@ define([
                         loadingBar.stop();
                     }, 300);
                 })
-                .on('message', function(e, data) {
+                .on('alertMessage', function(e, data) {
                     if (data) {
                         dialogAlert(data.message, data.action);
                     }

--- a/views/js/controller/runtime/deliveryExecution.js
+++ b/views/js/controller/runtime/deliveryExecution.js
@@ -22,8 +22,9 @@ define([
     'jquery',
     'helpers',
     'taoDelivery/controller/runtime/fullScreen',
-    'layout/loading-bar'
-], function(_, $, helpers, fullScreen, loadingBar){
+    'layout/loading-bar',
+    'ui/dialog'
+], function(_, $, helpers, fullScreen, loadingBar, dialog){
     'use strict';
 
     var $frameContainer,
@@ -92,6 +93,11 @@ define([
                     setTimeout(function(){
                         loadingBar.stop();
                     }, 300);
+                })
+                .on('message', function(e, data) {
+                    if (data) {
+                        dialog.alert(data.message, data.action);
+                    }
                 })
                 .on('shutdown-com', function(){
                     //use when we want to stop all exchange between frames

--- a/views/js/controller/runtime/deliveryExecution.js
+++ b/views/js/controller/runtime/deliveryExecution.js
@@ -96,7 +96,7 @@ define([
                         loadingBar.stop();
                     }, 300);
                 })
-                .on('alertMessage', function(e, data) {
+                .on('messagealert', function(e, data) {
                     if (data) {
                         dialogAlert(data.message, data.action);
                     }

--- a/views/js/controller/runtime/deliveryExecution.js
+++ b/views/js/controller/runtime/deliveryExecution.js
@@ -23,8 +23,8 @@ define([
     'helpers',
     'taoDelivery/controller/runtime/fullScreen',
     'layout/loading-bar',
-    'ui/dialog'
-], function(_, $, helpers, fullScreen, loadingBar, dialog){
+    'ui/dialog/alert'
+], function(_, $, helpers, fullScreen, loadingBar, dialogAlert){
     'use strict';
 
     var $frameContainer,
@@ -98,7 +98,7 @@ define([
                 })
                 .on('message', function(e, data) {
                     if (data) {
-                        dialog.alert(data.message, data.action);
+                        dialogAlert(data.message, data.action);
                     }
                 })
                 .on('shutdown-com', function(){

--- a/views/js/controller/runtime/deliveryExecution.js
+++ b/views/js/controller/runtime/deliveryExecution.js
@@ -83,6 +83,8 @@ define([
                         window.location = data.destination;
                     }
                 });
+            }).onExit(function() {
+                window.location = options.exitDeliveryExecution;
             });
 
             $(document)

--- a/views/templates/DeliveryServer/layout.tpl
+++ b/views/templates/DeliveryServer/layout.tpl
@@ -34,6 +34,7 @@ use oat\tao\model\theme\Theme;
 
                                 deliveryExecution.start({
                                     serviceApi : <?=get_data('serviceApi')?>,
+                                    exitDeliveryExecution : '<?=get_data('returnUrl')?>',
                                     finishDeliveryExecution : '<?=get_data('finishUrl')?>',
                                     deliveryExecution : '<?=get_data('deliveryExecution')?>',
                                     deliveryServerConfig : <?=get_data('deliveryServerConfig')?>


### PR DESCRIPTION
Related to:
- https://oat-sa.atlassian.net/browse/TAO-1775
- https://oat-sa.atlassian.net/browse/TAO-1773

Requires:
- https://github.com/oat-sa/tao-core/pull/637
- https://github.com/oat-sa/tao-core/pull/638

Listen to message event to display message. This behavior is added here instead of the the Test Runner to avoid issue with the GUI (some parts are inside the parent frame while others are inside the nested frame: the overlay mask cannot overlap all if it's set in the nested frame)

Add exit action to allow the return to index in case of error in the test