### PR TITLE
All executions retrieved for testtaker

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '4.4.0',
+    'version' => '4.4.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=5.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -172,6 +172,16 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('4.0.0');
         }
 
-        $this->skip('4.0.0', '4.4.0');
+        $this->skip('4.0.0', '4.4.1');
+
+        if ($this->isVersion('4.4.0')) {
+            \common_ext_ExtensionsManager::singleton()->isInstalled('taoProctoring');
+            $ext = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoDelivery');
+            $i = $ext->getConfig(\taoDelivery_models_classes_execution_ServiceProxy::CONFIG_KEY);
+            $i->setOption(\taoDelivery_models_classes_execution_KeyValueService::OPTION_EXECUTION_STATE_INTERFACE,
+                '\oat\taoProctoring\model\execution\DeliveryExecution');
+            $ext->setConfig(\taoDelivery_models_classes_execution_ServiceProxy::CONFIG_KEY, $i);
+            $this->setVersion('4.4.1');
+        }
     }
 }


### PR DESCRIPTION
One of the cases when this fix helps to resolve issues:
Incorrect counting of delivery execution for user allow him to perform more attempts for deliveries, e.g. if the previous attempt has been paused, terminated or has any other status rather that active or finished. 