### PR TITLE
Use set/get route to access urlservice options

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,10 +27,10 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '6.0.3',
+    'version' => '6.0.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
-        'tao' => '>=9.0.0',
+        'tao' => '>=10.3.2',
         'taoResultServer' => '>=2.6'
     ),
     'install' => array(

--- a/scripts/install/installDeliveryLogout.php
+++ b/scripts/install/installDeliveryLogout.php
@@ -27,7 +27,7 @@ class installDeliveryLogout extends \oat\oatbox\extension\InstallAction
         
         /*@var $routeService \oat\tao\model\mvc\DefaultUrlService */
         $routeService = $this->getServiceManager()->get(\oat\tao\model\mvc\DefaultUrlService::SERVICE_ID);
-        $routeService->setOption('logoutDelivery', 
+        $routeService->setRoute('logoutDelivery',
                     [
                         'ext'        => 'taoDelivery',
                         'controller' => 'DeliveryServer',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -185,7 +185,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             /*@var $routeService \oat\tao\model\mvc\DefaultUrlService */
             $routeService = $this->getServiceManager()->get(\oat\tao\model\mvc\DefaultUrlService::SERVICE_ID);
-            $routeService->setOption('logoutDelivery',
+            $routeService->setRoute('logoutDelivery',
                         [
                             'ext'        => 'taoDelivery',
                             'controller' => 'DeliveryServer',
@@ -211,6 +211,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('4.9.0');
         }
 
-        $this->skip('4.9.0', '6.0.3');
+        $this->skip('4.9.0', '6.0.4');
     }
 }


### PR DESCRIPTION
Create assessors to access configurable routes to make easier to override it
Requires https://github.com/oat-sa/tao-core/pull/1322