### PR TITLE
Fix/appropriate log level state

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '6.5.0',
+    'version' => '6.5.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=10.20.0',

--- a/model/execution/AbstractStateService.php
+++ b/model/execution/AbstractStateService.php
@@ -79,7 +79,7 @@ abstract class AbstractStateService extends ConfigurableService implements State
     {
         $prevState = $deliveryExecution->getState();
         if ($prevState->getUri() === $state) {
-            $this->logWarning('Delivery execution '.$deliveryExecution->getIdentifier().' already in state '.$state);
+            $this->logDebug('Delivery execution '.$deliveryExecution->getIdentifier().' already in state '.$state);
             return false;
         }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -279,5 +279,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             }
             $this->setVersion('6.5.0');
         }
+        
+        $this->skip('6.5.0', '6.5.1');
     }
 }


### PR DESCRIPTION
In order to make devops life easier in terms of log analysis, it seems appropriate to change this particular log's level. Indeed, it triggers a warning (with stack trace) for each delivery execution instantiation.

Thanks for them!