### PR TITLE
Fix guest access

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -63,14 +63,22 @@ class DeliveryServer extends \tao_actions_CommonModule
 		$this->executionService = taoDelivery_models_classes_execution_ServiceProxy::singleton();
 	}
 	
-	/**
-	 * @return DeliveryExecution
-	 */
-	protected function getCurrentDeliveryExecution() {
-	    $id = \tao_helpers_Uri::decode($this->getRequestParameter('deliveryExecution'));
-	    return $this->executionService->getDeliveryExecution($id);
-	}
-		
+    /**
+    * @return DeliveryExecution
+    */
+    protected function getCurrentDeliveryExecution()
+    {
+        $id = \tao_helpers_Uri::decode($this->getRequestParameter('deliveryExecution'));
+
+        if ($id) {
+            return $this->executionService->getDeliveryExecution($id);
+        }
+
+        else {
+            return null;
+        }
+    }
+
 	/**
      * Set a view with the list of process instances (both started or finished) and available process definitions
 	 *
@@ -282,18 +290,22 @@ class DeliveryServer extends \tao_actions_CommonModule
 	
     /**
      * Defines the returning URL in the top-right corner action menu
-     * 
+     *
      * @return string
      */
-	protected function getReturnUrl()
-	{
-	    if($this->getServiceManager()->has(ReturnUrlService::SERVICE_ID)){
-            $deliveryExecution = $this->getCurrentDeliveryExecution();
-	        return $this->getServiceManager()->get(ReturnUrlService::SERVICE_ID)->getReturnUrl($deliveryExecution->getIdentifier());
+     protected function getReturnUrl()
+     {
+        $deliveryExecution = $this->getCurrentDeliveryExecution();
+        $serviceManager = $this->getServiceManager();
+
+        if ( ! is_null($deliveryExecution) && $serviceManager->has(ReturnUrlService::SERVICE_ID) ) {
+            $returnUrlService = $serviceManager->get(ReturnUrlService::SERVICE_ID);
+            return $returnUrlService->getReturnUrl($deliveryExecution->getIdentifier());
         }
-	    return _url('index', 'DeliveryServer', 'taoDelivery');
-	}
-    
+
+        return _url('index', 'DeliveryServer', 'taoDelivery');
+     }
+
     /**
      * Defines the URL of the finish delivery execution action
      * 

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '6.5.0',
+    'version' => '6.5.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=10.20.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -279,5 +279,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             }
             $this->setVersion('6.5.0');
         }
+
+        $this->skip('6.5.0', '6.5.1');
     }
 }


### PR DESCRIPTION
Guest access is broken due to an error thrown when retrieving the current delivery execution. This essentially adds a check to ensure a uri parameter exists.

To replicate error, simply click 'Guest Access' on a login page.

@antoinerobin, feel free to change/update my code as you like. Sometimes it's best to keep the git blame with the code author.