### PR TITLE
Fixed migration from old deliveryServer config with legacy class name

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '10.0.2',
+    'version' => '10.0.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=18.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -357,6 +357,16 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('9.8.0', '10.0.2');
-      
+
+        if ($this->isVersion('10.0.2')) {
+            $deliveryServerService = $this->safeLoadService(DeliveryServerService::SERVICE_ID);
+            if (!$deliveryServerService instanceof DeliveryServerService) {
+                $oldOptions = $deliveryServerService->getOptions();
+                $deliveryServerService = new DeliveryServerService($oldOptions);
+                $this->getServiceManager()->register(DeliveryServerService::SERVICE_ID, $deliveryServerService);
+            }
+            $this->setVersion('10.0.3');
+        }
+
     }
 }


### PR DESCRIPTION
According to https://oat-sa.atlassian.net/browse/TAO-6478