### PR TITLE
TAO-7282 Fixed delivery theme id retrieval from DB upon delivery launch

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '12.3.0',
+    'version' => '12.3.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=21.0.0',

--- a/models/classes/theme/DeliveryThemeDetailsProvider.php
+++ b/models/classes/theme/DeliveryThemeDetailsProvider.php
@@ -98,7 +98,7 @@ class DeliveryThemeDetailsProvider extends \Actions implements ThemeDetailsProvi
     public function getDeliveryThemeId($deliveryId)
     {
         $themeId = $this->getDeliveryThemeIdFromCache($deliveryId);
-        if (empty($themeId)) {
+        if ($themeId === false) {
             $themeId = $this->getDeliveryThemeIdFromDb($deliveryId);
             $this->storeDeliveryThemeIdToCache($deliveryId, $themeId);
         }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -385,6 +385,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('12.1.0');
         }
 
-        $this->skip('12.1.0', '12.3.0');
+        $this->skip('12.1.0', '12.3.1');
     }
 }


### PR DESCRIPTION
Theme ID can be null, when there is no theme selected, however 'common_persistence_KvDriver' implementations return false upon failed 'get' calls.