### PR TITLE
Fix/json decode in key value service

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '13.0.0',
+    'version' => '13.0.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=27.2.0',

--- a/model/execution/implementation/KeyValueService.php
+++ b/model/execution/implementation/KeyValueService.php
@@ -75,7 +75,7 @@ class KeyValueService extends ConfigurableService implements Service
     {
         $returnValue = array();
         $data = $this->getPersistence()->get(self::USER_DELIVERY_PREFIX . $userUri . $compiled->getUri());
-        $keys = $data !== false ? json_decode($data) : array();
+        $keys = $data !== false ? json_decode($data, true) : array();
         if (is_array($keys)) {
             foreach ($keys as $key) {
                 $returnValue[$key] = $this->getDeliveryExecution($key);
@@ -133,7 +133,7 @@ class KeyValueService extends ConfigurableService implements Service
     private function addDeliveryToUserExecutionList($userId, $assemblyId, $executionId)
     {
         $uid = self::USER_DELIVERY_PREFIX . $userId . $assemblyId;
-        $data = json_decode($this->getPersistence()->get($uid));
+        $data = json_decode($this->getPersistence()->get($uid), true);
         if (!$data) {
             $data = [];
         }
@@ -150,7 +150,7 @@ class KeyValueService extends ConfigurableService implements Service
     {
         $returnValue = array();
         $data = $this->getPersistence()->get(self::USER_EXECUTIONS_PREFIX . $userUri . $status);
-        $keys = $data !== false ? json_decode($data) : array();
+        $keys = $data !== false ? json_decode($data, true) : array();
         if (is_array($keys)) {
             foreach ($keys as $key) {
                 $de = $this->getDeliveryExecution($key);
@@ -282,7 +282,7 @@ class KeyValueService extends ConfigurableService implements Service
     {
         $userId = $deliveryExecution->getUserIdentifier();
         $oldData = $this->getPersistence()->get(self::USER_EXECUTIONS_PREFIX . $userId . $old);
-        $oldStateKeys = $oldData !== false ? json_decode($oldData) : [];
+        $oldStateKeys = $oldData !== false ? json_decode($oldData, true) : [];
         $oldStateExecutions = [];
         if (is_array($oldStateKeys)) {
             foreach ($oldStateKeys as $key) {
@@ -295,7 +295,7 @@ class KeyValueService extends ConfigurableService implements Service
         }
 
         $newData = $this->getPersistence()->get(self::USER_EXECUTIONS_PREFIX . $userId . $new);
-        $newStateKeys = $newData !== false ? json_decode($newData) : [];
+        $newStateKeys = $newData !== false ? json_decode($newData, true) : [];
         $newStateExecutions = [];
         if (is_array($newStateKeys) && !isset($newStateKeys[$deliveryExecution->getIdentifier()])) {
             foreach ($newStateKeys as $key) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -397,6 +397,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('12.1.0');
         }
 
-        $this->skip('12.1.0', '13.0.0');
+        $this->skip('12.1.0', '13.0.1');
     }
 }


### PR DESCRIPTION
I found a lot of such messages in the act log:
```
{
    "level": "proxy_fcgi:error",
    "pid": "1050:tid 140454817359616",
    "client": "10.0.0.171:42160",
    "message": "AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught Error: Cannot use object of type stdClass as array in /var/www/html/tao/taoDelivery/model/execution/implementation/KeyValueService.php:140\\nStack trace:\\n#0 /var/www/html/tao/taoDelivery/model/execution/implementation/KeyValueService.php(111): oat\\\\taoDelivery\\\\model\\\\execution\\\\implementation\\\\KeyValueService->addDeliveryToUserExecutionList('1143993935', 'https://usact02...', 'kve_de_https://...')\\n#1 /var/www/html/tao/taoDelivery/model/execution/AbstractStateService.php(67): oat\\\\taoDelivery\\\\model\\\\execution\\\\implementation\\\\KeyValueService->spawnDeliveryExecution('Delivery of Wor...', 'https://usact02...', '1143993935', 'http://www.tao....')\\n#2 /var/www/html/tao/ltiDeliveryProvider/model/LTIDeliveryTool.php(108): oat\\\\taoDelivery\\\\model\\\\execution\\\\AbstractStateService->createDeliveryExecution('https://usact02...', Object(oat\\\\taoLti\\\\models\\\\classes\\\\user\\\\LtiUser), 'Delivery of Wor...')\\n#3 /var/www/html/tao/ltiDeliveryProvider/model/actions/GetActiveDeliveryExecution.php(85): oat\\\\l...\\n', referer: https://act-stress.taocloud.org/ltiDeliveryProvider/DeliveryTool/launchQueue?position=8427&delivery=https%3A%2F%2Fusact02dee.usact.taocloud.org%2F%23i154473215021333184117",
    "instance_id": "i-080fcc231899e2d56",
    "stack": "usact02dee",
    "host_type": "taocloud/ws/delivery"
}
```