### PR TITLE
Feature/nex 19 test provider plugins format

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '13.2.1',
+    'version' => '13.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=36.1.0',

--- a/model/container/delivery/LegacyClientContainer.php
+++ b/model/container/delivery/LegacyClientContainer.php
@@ -83,8 +83,10 @@ class LegacyClientContainer extends AbstractContainer
         // set the test parameters
         $container->setData('testDefinition', $this->getSourceTest($execution));
         $container->setData('testCompilation', $this->getPrivateDirId($execution).'|'.$this->getPublicDirId($execution));
-        $container->setData('providers', $containerService->getProviders($execution));
-        $container->setData('plugins', $containerService->getPlugins($execution));
+
+        $providers = $containerService->getProviders($execution);
+        $providers['plugins'] = $containerService->getPlugins($execution);
+        $container->setData('providers', $providers);
         $container->setData('bootstrap', $containerService->getBootstrap($execution));
         $container->setData('serviceCallId', $execution->getIdentifier());
         $container->setData('deliveryExecution', $execution->getIdentifier());

--- a/model/container/delivery/LegacyClientContainer.php
+++ b/model/container/delivery/LegacyClientContainer.php
@@ -84,9 +84,7 @@ class LegacyClientContainer extends AbstractContainer
         $container->setData('testDefinition', $this->getSourceTest($execution));
         $container->setData('testCompilation', $this->getPrivateDirId($execution).'|'.$this->getPublicDirId($execution));
 
-        $providers = $containerService->getProviders($execution);
-        $providers['plugins'] = $containerService->getPlugins($execution);
-        $container->setData('providers', $providers);
+        $container->setData('providers', $containerService->getProviders($execution));
         $container->setData('bootstrap', $containerService->getBootstrap($execution));
         $container->setData('serviceCallId', $execution->getIdentifier());
         $container->setData('deliveryExecution', $execution->getIdentifier());

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -411,7 +411,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('13.1.1');
         }
 
-        $this->skip('13.1.1', '13.2.1');
+        $this->skip('13.1.1', '13.3.0');
     }
 
 }

--- a/views/templates/DeliveryServer/container/client/loader.tpl
+++ b/views/templates/DeliveryServer/container/client/loader.tpl
@@ -7,13 +7,14 @@ use oat\tao\helpers\Template;
     Template::js('loader/taoQtiTestRunner.min.js', 'taoQtiTest'),
     'taoQtiTest/controller/runner/runner',
     [
-        'exitUrl'              => get_data('returnUrl'),
         'testDefinition'       => get_data('testDefinition'),
         'testCompilation'      => get_data('testCompilation'),
         'serviceCallId'        => get_data('serviceCallId'),
         'deliveryServerConfig' => get_data('deliveryServerConfig'),
         'bootstrap'            => get_data('bootstrap'),
         'providers'            => get_data('providers'),
-        'plugins'              => get_data('plugins')
+        'options'              => [
+            'exitUrl' => get_data('returnUrl')
+        ]
     ]
 ); ?>


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/NEX-19

Adapt the test configuration to the new format (to keep the change backward compatible)

Companion PRs : 

 - [ ] https://github.com/oat-sa/extension-tao-test/pull/288
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1540

To be tested along with the other PRs : start a test after having updated your installation