### PR TITLE
Fix/nex 462/display lti error feedback

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'version' => '14.1.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
-        'tao' => '>=38.9.0',
+        'tao' => '>=39.0.6',
     	'generis' => '>=11.2.3',
         'taoResultServer' => '>=5.0.0'
     ),

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.1.1',
+    'version' => '14.1.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=38.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -436,6 +436,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.0.0');
         }
 
-        $this->skip('14.0.0', '14.1.1');
+        $this->skip('14.0.0', '14.1.2');
     }
 }

--- a/views/js/controller/DeliveryServer/index.js
+++ b/views/js/controller/DeliveryServer/index.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
  *
  */
 

--- a/views/js/controller/DeliveryServer/index.js
+++ b/views/js/controller/DeliveryServer/index.js
@@ -30,7 +30,8 @@ define([
     'core/router',
     'ui/feedback',
     'core/logger',
-    'layout/loading-bar'
+    'layout/loading-bar',
+    'url-polyfill'
 ], function($, _, __, module, router, feedback, loggerFactory, loadingBar){
     'use strict';
 

--- a/views/js/controller/DeliveryServer/index.js
+++ b/views/js/controller/DeliveryServer/index.js
@@ -42,7 +42,7 @@ define([
      * @param {String} level - in supported feedbacks' levels
      * @param {String} content - the message to display
      */
-    const displayPermanentMessage = function displayPermanentMessage(level, content){
+    const displayPermanentMessage = (level, content) => {
         if(level && content){
             feedback($('.permanent-feedback'))[level](content, {
                 timeout : -1,
@@ -55,7 +55,7 @@ define([
      * Extract standard LTI error parameters from query string
      * @returns {Object} LTI error parameters
      */
-    const getLTIErrorParameters = function getLTIErrorParameters() {
+    const getLTIErrorParameters = () => {
         const { searchParams } = new URL(window.location.href);
 
         return ['lti_errormsg', 'lti_errorlog'].reduce((params, paramName) => {
@@ -107,7 +107,7 @@ define([
                 displayPermanentMessage('error', ltiErrorMsg.length ? ltiErrorMsg : __('An error occurred!'));
             };
             if (ltiErrorLog) {
-                logger.error(`${ltiErrorMsg} ${ltiErrorLog}`);
+                logger.error(ltiErrorLog);
             };
 
             $('a.entry-point').on('click', function (e) {


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/NEX-462

Depends on: https://github.com/oat-sa/tao-core/pull/2293

Changes applied in `views/js/controller/DeliveryServer/index.js ` so that:
When returning to a URL such as
```
https://currentgen.docker.localhost/taoDelivery/DeliveryServer/index?lti_errormsg=Sorry%2C+an+unexpected+error+happened+during+the+test.&lti_errorlog=Cannot+find+module+%27.%2Frunner%2Fplugins%2FcolorContrast.js%27
```
- The `lti_errormsg` param from the URL query string will be displayed in a feedback bubble
- Both params will be logged by the FE logger (appears in the console depending on your platform config: (`core/logger` levels in `config/tao/client_lib_config_registry.conf.php`))

I included a polyfill for `URL` for IE11, and verified it will be loaded.