### PR TITLE
Feature/tao 9632/implement enhanced rds metrics monitoring

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.4.0',
+    'version' => '14.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=39.0.6',

--- a/model/Capacity/InfrastructureCapacityService.php
+++ b/model/Capacity/InfrastructureCapacityService.php
@@ -75,6 +75,12 @@ class InfrastructureCapacityService extends ConfigurableService implements Capac
             $this->logCapacityCalculationDetails($capacity, $currentInfrastructureLoad, $infrastructureLoadLimit, $taoLimit);
             $persistence->set(self::CAPACITY_CACHE_KEY, $capacity, $this->getOption(self::OPTION_TTL) ?? self::DEFAULT_TTL);
             $this->getEventManager()->trigger(new SystemCapacityUpdatedEvent($cachedCapacity, $capacity));
+
+            /** @var DeliveryExecutionCounterInterface $deliveryExecutionService */
+            $deliveryExecutionService = $this->getServiceLocator()->get(DeliveryExecutionCounterInterface::SERVICE_ID);
+            $deliveryExecutionService->refresh(DeliveryExecution::STATE_ACTIVE);
+            $currentActiveTestTakers = $deliveryExecutionService->count(DeliveryExecution::STATE_ACTIVE);
+            
             $persistence->set(self::ACTIVE_EXECUTIONS_CACHE_KEY, $currentActiveTestTakers);
             $previousActiveTestTakers = $currentActiveTestTakers;
         }

--- a/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
+++ b/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
@@ -121,6 +121,7 @@ class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements Infrastru
     {
         $metricValue = 0;
         if (!$result->hasKey('events')) {
+            $this->logAlert("CloudWatch Logs doesn't have log events records for RDS Metrics.");
             return $metricValue;
         }
         $logEvents = $result->get('events');

--- a/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
+++ b/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
@@ -76,7 +76,7 @@ class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements Infrastru
     private function getLogEventsLimit()
     {
         if (!$this->hasOption(self::OPTION_LOG_EVENTS_LIMIT)) {
-            self::DEFAULT_LOG_EVENTS_LIMIT;
+            return self::DEFAULT_LOG_EVENTS_LIMIT;
         }
 
         return $this->getOption(self::OPTION_LOG_EVENTS_LIMIT);

--- a/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
+++ b/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
@@ -88,7 +88,7 @@ class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements Infrastru
     private function getAwsClient()
     {
         if (!$this->awsClient) {
-            $this->awsClient = $this->getServiceManager()->get('generis/awsClient');
+            $this->awsClient = $this->getServiceLocator()->get('generis/awsClient');
         }
         return $this->awsClient;
     }
@@ -107,6 +107,6 @@ class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements Infrastru
         $logEvent = $logEvents[0];
         $logMessage = json_decode($logEvent['message'], true);
 
-        return $logMessage['cpuUtilization']['total'];
+        return (float) $logMessage['cpuUtilization']['total'];
     }
 }

--- a/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
+++ b/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
@@ -19,6 +19,11 @@ class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements Infrastru
     const OPTION_LOG_EVENTS_LIMIT = 'logEventsLimit';
 
     /**
+     * @var int
+     */
+    const DEFAULT_LOG_EVENTS_LIMIT = 1;
+
+    /**
      * @var AwsClient
      */
     private $awsClient;
@@ -71,7 +76,7 @@ class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements Infrastru
     private function getLogEventsLimit()
     {
         if (!$this->hasOption(self::OPTION_LOG_EVENTS_LIMIT)) {
-            return 1; // Default limit for log events number.
+            self::DEFAULT_LOG_EVENTS_LIMIT;
         }
 
         return $this->getOption(self::OPTION_LOG_EVENTS_LIMIT);

--- a/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
+++ b/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
@@ -1,0 +1,142 @@
+<?php
+
+
+namespace oat\taoDelivery\model\Metrics;
+
+use Aws\Result;
+use oat\awsTools\AwsClient;
+use oat\tao\model\metrics\implementations\abstractMetrics;
+
+class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements InfrastructureLoadMetricInterface
+{
+    /** @var string */
+    const OPTION_LOG_GROUP_NAME = 'logGroupName';
+
+    /** @var string */
+    const OPTION_LOG_STREAM_NAME = 'logStreamName';
+
+    /** @var string */
+    const OPTION_AVERAGE_PERIOD = 'averagePeriod';
+
+    const AVERAGE_LOAD_1_MIN = 'one';
+    const AVERAGE_LOAD_5_MIN = 'five';
+    const AVERAGE_LOAD_15_MIN = 'fifteen';
+
+    /**
+     * @var AwsClient
+     */
+    private $awsClient;
+
+    /**
+     * @var array List of allowed values for averagePeriod parameter
+     */
+    private $averageAllowedValues = [
+        self::AVERAGE_LOAD_1_MIN,
+        self::AVERAGE_LOAD_5_MIN,
+        self::AVERAGE_LOAD_15_MIN
+    ];
+
+    /**
+     * @return mixed
+     * @throws MetricConfigurationException
+     */
+    private function getLogGroupName()
+    {
+        if (!$this->hasOption(self::OPTION_LOG_GROUP_NAME)) {
+            throw new MetricConfigurationException('AWS CloudWatch Logs group not configured.');
+        }
+
+        return $this->getOption(self::OPTION_LOG_GROUP_NAME);
+    }
+
+    /**
+     * @return mixed
+     * @throws MetricConfigurationException
+     */
+    private function getLogStreamName()
+    {
+        if (!$this->hasOption(self::OPTION_LOG_STREAM_NAME)) {
+            throw new MetricConfigurationException('AWS CloudWatch Logs stream not configured.');
+        }
+
+        return $this->getOption(self::OPTION_LOG_STREAM_NAME);
+    }
+
+    /**
+     * @return string
+     */
+    private function getAveragePeriod()
+    {
+        $averagePeriod = $this->getOption(self::OPTION_AVERAGE_PERIOD);
+        if (!$averagePeriod && !in_array($averagePeriod, $this->averageAllowedValues)) {
+            $averagePeriod = self::AVERAGE_LOAD_1_MIN;
+        }
+
+        return $averagePeriod;
+    }
+
+    /**
+     * @param bool $force
+     * @return bool|int|mixed|string|null
+     * @throws \common_Exception
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     */
+    public function collect($force = false)
+    {
+        if ($force || !$metricValue = $this->getPersistence()->get(self::class)) {
+            $metricValue = $this->getMetric();
+            $this->getPersistence()->set(self::class, $metricValue, $this->getOption(self::OPTION_TTL));
+        }
+
+        return $metricValue;
+    }
+
+    /**
+     * @return mixed
+     * @throws MetricConfigurationException
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     */
+    private function getMetric()
+    {
+        $cloudWatchClient = $this->getAwsClient()->getCloudWatchLogsClient();
+        $result = $cloudWatchClient->getLogEvents([
+            'limit' => 1,
+            'logGroupName' => $this->getLogGroupName(), // REQUIRED
+            'logStreamName' => $this->getLogStreamName(), // REQUIRED
+            'startFromHead' => false,
+        ]);
+        $this->logInfo('RDS_METRICS:' . json_encode($result->toArray()));
+        return $this->parseMetricValue($result);
+    }
+
+    /**
+     * Requires lib-generis-aws at least 0.10.0
+     * @return AwsClient
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     */
+    public function getAwsClient()
+    {
+        if (!$this->awsClient) {
+            $this->awsClient = $this->getServiceManager()->get('generis/awsClient');
+        }
+        return $this->awsClient;
+    }
+
+    /**
+     * @param Result $result
+     * @return mixed
+     */
+    private function parseMetricValue(Result $result)
+    {
+        $default = 0;
+        if (!$result->hasKey('events')) {
+            return $default;
+        }
+        $logEvents = $result->get('events');
+        $logEvent = $logEvents[0];
+        $logMessage = json_decode($logEvent['message'], true);
+        $averagePeriod = $this->getAveragePeriod();
+
+        return $logMessage['loadAverageMinute'][$averagePeriod];
+    }
+}

--- a/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
+++ b/model/Metrics/AwsCloudWatchLogRdsLoadMetric.php
@@ -65,7 +65,6 @@ class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements Infrastru
     /**
      * @return mixed
      * @throws MetricConfigurationException
-     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
      */
     private function getMetric()
     {
@@ -83,7 +82,6 @@ class AwsCloudWatchLogRdsLoadMetric extends abstractMetrics implements Infrastru
     /**
      * Requires lib-generis-aws at least 0.10.0
      * @return AwsClient
-     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
      */
     private function getAwsClient()
     {

--- a/model/Metrics/AwsLoadMetric.php
+++ b/model/Metrics/AwsLoadMetric.php
@@ -22,8 +22,6 @@ use DateInterval;
 use DateTime;
 use oat\awsTools\AwsClient;
 use oat\tao\model\metrics\implementations\abstractMetrics;
-use oat\taoDelivery\model\execution\Counter\DeliveryExecutionCounterInterface;
-use oat\taoDelivery\model\execution\DeliveryExecution;
 
 class AwsLoadMetric extends abstractMetrics implements InfrastructureLoadMetricInterface
 {
@@ -64,9 +62,6 @@ class AwsLoadMetric extends abstractMetrics implements InfrastructureLoadMetricI
         if (!$active || $force) {
             $active = $this->getMetric();
             $this->getPersistence()->set(self::class, $active, $this->getOption(self::OPTION_TTL));
-            /** @var DeliveryExecutionCounterInterface $deliveryExecutionService */
-            $deliveryExecutionService = $this->getServiceLocator()->get(DeliveryExecutionCounterInterface::SERVICE_ID);
-            $deliveryExecutionService->refresh(DeliveryExecution::STATE_ACTIVE);
         }
         return $active;
 

--- a/model/Metrics/MetricConfigurationException.php
+++ b/model/Metrics/MetricConfigurationException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace oat\taoDelivery\model\Metrics;
+
+
+class MetricConfigurationException extends \common_Exception
+{
+
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -445,6 +445,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.4.0');
+        $this->skip('14.3.0', '14.5.0');
     }
 }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-9632

Implement new service to get enhanced RDC CPU metrics from CloudWatch Logs.
To test:
set config for MetricsService:
```return new oat\tao\model\metrics\MetricsService(array(
    'metrics' => array(
        'oat\\ltiDeliveryProvider\\model\\metrics\\implementation\\activeExecutionsMetrics' => new oat\ltiDeliveryProvider\model\metrics\implementation\activeExecutionsMetrics(array(
            'ttl' => 1,
            'persistence' => 'metricsCache'
        )),
        InfrastructureLoadMetricInterface::class => new AwsCloudWatchLogRdsLoadMetric(array(
            'ttl' => 60,
            'persistence' => 'default_kv',
            AwsCloudWatchLogRdsLoadMetric::OPTION_LOG_GROUP_NAME => 'RDSOSMetrics',
            AwsCloudWatchLogRdsLoadMetric::OPTION_LOG_STREAM_NAME => 'STREAM_NAME',
        )),
    )
));
```

Set configs for InfrastructureCapacityService:
```
return new oat\taoDelivery\model\Capacity\InfrastructureCapacityService(array(
    'persistence' => 'default_kv',
    InfrastructureCapacityService::OPTION_INFRASTRUCTURE_LOAD_LIMIT => 80,
    InfrastructureCapacityService::OPTION_TAO_CAPACITY_LIMIT => 200,
    InfrastructureCapacityService::OPTION_TTL => 60,
));
```

configure AWS client.