### PR TITLE
ACTP-357 `Resume` button is not announced as a button or an action on Delivery page

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.7.2',
+    'version' => '14.7.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=39.0.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.7.2');
+        $this->skip('14.3.0', '14.7.3');
     }
 }

--- a/views/templates/DeliveryServer/delivery_entry.tpl
+++ b/views/templates/DeliveryServer/delivery_entry.tpl
@@ -4,20 +4,21 @@ $delivery = get_data('delivery');
 ?>
 <li>
     <a class="block entry-point entry-point-all-deliveries <?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? "" : "disabled" ?>"
-    data-launch_url="<?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? $delivery[Delivery::LAUNCH_URL] : "#" ?>"
-    tabindex="0">
+        data-launch_url="<?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? $delivery[Delivery::LAUNCH_URL] : "#" ?>"
+        tabindex="0">
     <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
 
-    <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>
-    <p><?= $desc?></p>
-    <?php endforeach; ?>
-    <div class="clearfix">
-            <span class="text-link"
-                  role="button"
-                  aria-label="<?= __('Start button')?>. <?= __('To activate press enter') ?>"
+        <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>
+        <p><?= $desc?></p>
+        <?php endforeach; ?>
+        <div class="clearfix">
+            <span
+                class="text-link"
+                role="button"
+                aria-label="<?= __('Start button')?>. <?= __('To activate press enter') ?>"
             >
                 <span class="icon-play"></span> <?= __('Start') ?>
             </span>
-    </div>
+        </div>
     </a>
 </li>

--- a/views/templates/DeliveryServer/delivery_entry.tpl
+++ b/views/templates/DeliveryServer/delivery_entry.tpl
@@ -4,17 +4,20 @@ $delivery = get_data('delivery');
 ?>
 <li>
     <a class="block entry-point entry-point-all-deliveries <?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? "" : "disabled" ?>"
-        data-launch_url="<?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? $delivery[Delivery::LAUNCH_URL] : "#" ?>"
-        tabindex="0">
-        <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
+    data-launch_url="<?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? $delivery[Delivery::LAUNCH_URL] : "#" ?>"
+    tabindex="0">
+    <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
 
-        <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>
-        <p><?= $desc?></p>
-        <?php endforeach; ?>
-        <div class="clearfix">
-            <span class="text-link">
+    <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>
+    <p><?= $desc?></p>
+    <?php endforeach; ?>
+    <div class="clearfix">
+            <span class="text-link"
+                  role="button"
+                  aria-label="<?= __('Start button')?>. <?= __('To activate press enter') ?>"
+            >
                 <span class="icon-play"></span> <?= __('Start') ?>
             </span>
-        </div>
+    </div>
     </a>
 </li>

--- a/views/templates/DeliveryServer/delivery_entry.tpl
+++ b/views/templates/DeliveryServer/delivery_entry.tpl
@@ -6,7 +6,7 @@ $delivery = get_data('delivery');
     <a class="block entry-point entry-point-all-deliveries <?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? "" : "disabled" ?>"
         data-launch_url="<?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? $delivery[Delivery::LAUNCH_URL] : "#" ?>"
         tabindex="0">
-    <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
+        <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
 
         <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>
         <p><?= $desc?></p>


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ACTP-357

`Resume` button is not announced as a button or an action on Delivery page

**How to test:**
- turn ON screenreader (NVDA / JAWS)
- login to ACT as a Guest user
- start a test, do not finish it, come back to Delivery page
- using keyboard navigate through the list of tests in "In progress" state, listen to SR's announcements

**Related pull requests**
https://github.com/oat-sa/extension-tao-delivery/pull/439
