### PR TITLE
ACTP-356 fix start button announce

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.7.2',
+    'version' => '14.7.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=39.0.6',

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.7.3',
+    'version' => '14.7.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=39.0.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.7.3');
+        $this->skip('14.3.0', '14.7.4');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.7.2');
+        $this->skip('14.3.0', '14.7.3');
     }
 }

--- a/views/templates/DeliveryServer/index.tpl
+++ b/views/templates/DeliveryServer/index.tpl
@@ -20,17 +20,21 @@ $warningMessage = get_data('warningMessage');
         <ul class="entry-point-box plain">
             <?php foreach ($resumableDeliveries as $delivery): ?>
                 <li>
-                    <a class="block entry-point entry-point-started-deliveries" data-launch_url="<?= $delivery[Delivery::LAUNCH_URL] ?>"
-                       tabindex="0" role="button" aria-label="<?= __("Resume") ?>"
-                    >
+                    <a class="block entry-point entry-point-started-deliveries"
+                        data-launch_url="<?= $delivery[Delivery::LAUNCH_URL] ?>"
+                        tabindex="0">
                         <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
 
                         <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>
-                        <p><?= $desc?></p>
+                        <p aria-hidden="true"><?= $desc?></p>
                         <?php endforeach; ?>
 
                         <div class="clearfix">
-                            <span class="text-link" href="<?= $delivery[Delivery::LAUNCH_URL] ?>">
+                            <span class="text-link"
+                                  href="<?= $delivery[Delivery::LAUNCH_URL] ?>"
+                                  role="button"
+                                  aria-label="<?= __('Resume button')?>. <?= __('To activate press enter') ?>"
+                            >
                                 <span class="icon-continue"></span> <?= __("Resume") ?>
                             </span>
                         </div>


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ACTP-356

`Start` button is not announced as a button or an action on Delivery page

**How to test:**
- turn ON screenreader (NVDA / JAWS)
- login to ACT as a Guest user
- using keyboard navigate through the list of available tests, listen to SR's announcements

**Related pull requests**
https://github.com/oat-sa/extension-tao-delivery/pull/438
