### PR TITLE
Fix/actp 357/progress cards readability

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.9.0',
+    'version' => '14.9.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=39.0.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.9.0');
+        $this->skip('14.3.0', '14.9.1');
     }
 }

--- a/views/templates/DeliveryServer/index.tpl
+++ b/views/templates/DeliveryServer/index.tpl
@@ -26,7 +26,7 @@ $warningMessage = get_data('warningMessage');
                         <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
 
                         <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>
-                        <p aria-hidden="true"><?= $desc?></p>
+                        <p><?= $desc?></p>
                         <?php endforeach; ?>
 
                         <div class="clearfix">


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ACTP-357

`Resume` button is not announced as a button or an action on Delivery page

**How to test:**
- turn ON screenreader (NVDA / JAWS)
- login to ACT as a Guest user
- start a test, do not finish it, come back to Delivery page
- using keyboard navigate through the list of tests in "In progress" state, listen to SR's announcements
