### PR TITLE
UDI-190: Render a favicon tag via a template

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,10 +34,10 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.9.1',
+    'version' => '14.9.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
-        'tao' => '>=41.9.1',
+        'tao' => '>=41.10.0',
         'generis' => '>=12.15.0',
         'taoResultServer' => '>=5.0.0'
     ],

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.9.1');
+        $this->skip('14.3.0', '14.9.2');
     }
 }

--- a/views/templates/DeliveryServer/layout.tpl
+++ b/views/templates/DeliveryServer/layout.tpl
@@ -9,11 +9,14 @@ use oat\tao\model\theme\Theme;
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title><?php echo __("TAO - An Open and Versatile Computer-Based Assessment Platform"); ?></title>
+
+        <?= Layout::renderThemeTemplate(Theme::CONTEXT_FRONTOFFICE, 'head') ?>
+
+        <title><?= __("TAO - An Open and Versatile Computer-Based Assessment Platform") ?></title>
+
         <link rel="stylesheet" href="<?= Template::css('tao-main-style.css', 'tao')?>"/>
         <link rel="stylesheet" href="<?= Template::css('tao-3.css', 'tao')?>"/>
         <link rel="stylesheet" href="<?= Template::css('delivery.css', 'taoDelivery') ?>"/>
-        <?= Layout::renderThemeTemplate(Theme::CONTEXT_FRONTOFFICE, 'head') ?>
 
         <link rel="stylesheet" href="<?= Layout::getThemeStylesheet(Theme::CONTEXT_FRONTOFFICE) ?>" />
 

--- a/views/templates/DeliveryServer/layout.tpl
+++ b/views/templates/DeliveryServer/layout.tpl
@@ -13,7 +13,7 @@ use oat\tao\model\theme\Theme;
         <link rel="stylesheet" href="<?= Template::css('tao-main-style.css', 'tao')?>"/>
         <link rel="stylesheet" href="<?= Template::css('tao-3.css', 'tao')?>"/>
         <link rel="stylesheet" href="<?= Template::css('delivery.css', 'taoDelivery') ?>"/>
-        <link rel="shortcut icon" href="<?= Template::img('favicon.ico', 'tao')?>"/>
+        <?= Layout::renderThemeTemplate(Theme::CONTEXT_FRONTOFFICE, 'head') ?>
 
         <link rel="stylesheet" href="<?= Layout::getThemeStylesheet(Theme::CONTEXT_FRONTOFFICE) ?>" />
 


### PR DESCRIPTION
- UDI-190 fix(layout): render a `favicon` `<link>` via `head` template
- UDI-190 fix(dependency): depend on `tao` `v41.10.0`, allowing `head` template usage
- UDI-190 fix(version): bump a fix one
- UDI-190 feat(layout): allow overriding a `title` tag via a themed `head` template

Depends on [tao PR #2469](https://github.com/oat-sa/tao-core/pull/2469)