### PR TITLE
REF-73: Delivery execution state controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ As a system administrator you also install it through the TAO Extension Manager:
 - Select _taoDelivery_ on the right hand side, check the box and hit _install_
 
 ## REST API
-[](https://openapi.taotesting.com/viewer/?url=https://raw.githubusercontent.com/oat-sa/extension-tao-delivery/master/doc/rest.json)
+[Open API Specification](https://openapi.taotesting.com/viewer/?url=https://raw.githubusercontent.com/oat-sa/extension-tao-delivery/master/doc/rest.json)
 
 <!-- Uncomment and describe if applicable
 ## LTI Endpoints

--- a/controller/DeliveryExecutionState.php
+++ b/controller/DeliveryExecutionState.php
@@ -32,7 +32,7 @@ use oat\taoDelivery\model\execution\StateServiceInterface;
 use tao_actions_CommonRestModule as RestModule;
 
 /** Kindly use `funcAcl` in order to assign the roles, having access to the controller */
-class DeliveryState extends RestModule
+class DeliveryExecutionState extends RestModule
 {
     public function put($uri): void
     {

--- a/controller/DeliveryState.php
+++ b/controller/DeliveryState.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+declare(strict_types=1);
+
+namespace oat\taoDelivery\controller;
+
+use common_exception_MissingParameter;
+use common_exception_NotFound as NotFoundException;
+use common_exception_RestApi as ApiException;
+use oat\taoDelivery\model\execution\Service;
+use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoDelivery\model\execution\StateServiceInterface;
+use tao_actions_CommonRestModule as RestModule;
+
+/** Kindly use `funcAcl` in order to assign the roles, having access to the controller */
+class DeliveryState extends RestModule
+{
+    public function put($uri): void
+    {
+        if (empty($uri)) {
+            $this->returnFailure(new common_exception_MissingParameter('uri'));
+        }
+
+        $state = $this->extractState();
+
+        $deliveryExecution = $this->getExecutionService()->getDeliveryExecution($uri);
+
+        try {
+            if ($deliveryExecution->getState()->getUri() !== $state) {
+                $deliveryExecution->setState($state);
+            }
+        } catch (NotFoundException $exception) {
+            throw new NotFoundException('Delivery execution not found', 404, $exception);
+        }
+
+        $this->returnSuccess([], false);
+    }
+
+    public function get($uri = null)
+    {
+        $this->returnFailure(new ApiException('Not implemented'));
+    }
+
+    public function post($uri = null)
+    {
+        $this->returnFailure(new ApiException('Not implemented'));
+    }
+
+    public function delete($uri = null)
+    {
+        $this->returnFailure(new ApiException('Not implemented'));
+    }
+
+    protected function getExecutionService(): Service
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID);
+    }
+
+    protected function getStateService(): StateServiceInterface
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(StateServiceInterface::SERVICE_ID);
+    }
+
+    private function extractState(): string
+    {
+        $data = json_decode((string)$this->getPsrRequest()->getBody(), true);
+
+        if (empty($data['value']) || !in_array($data['value'], $this->getStateService()->getDeliveriesStates(), true)) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $this->returnFailure(new common_exception_MissingParameter('value'));
+        }
+
+        return $data['value'];
+    }
+}

--- a/doc/rest.json
+++ b/doc/rest.json
@@ -149,7 +149,8 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "example": []
             }
           },
           "400": {

--- a/doc/rest.json
+++ b/doc/rest.json
@@ -83,41 +83,19 @@
             }
           },
           "400": {
-            "description": "Bad request if you send invalid parameters. deliveryExecution is mandatory.",
-            "examples": {
-              "application/json": {
-                "success": false,
-                "errorCode": 0,
-                "errorMsg": "At least one mandatory parameter was required but found missing in your request",
-                "version": "3.1.0"
-              }
-            },
-            "schema": {
-              "$ref": "#/definitions/errorModel"
-            }
+            "$ref": "#/responses/genericValidationError"
           },
           "401": {
-            "description": "Unauthorized"
+            "$ref": "#/responses/genericAuthenticationError"
           },
           "403": {
-            "description": "User isn't authorized to access to this functionality"
+            "$ref": "#/responses/genericAuthorizationError"
           },
           "404": {
-            "description": "Delivery can't be found",
-            "examples": {
-              "application/json": {
-                "success": false,
-                "errorCode": 0,
-                "errorMsg": "Delivery Execution not found",
-                "version": "3.1.0"
-              }
-            },
-            "schema": {
-              "$ref": "#/definitions/errorModel"
-            }
+            "$ref": "#/responses/executionNotFoundError"
           },
           "500": {
-            "description": "Internal error (should not occur)"
+            "$ref": "#/responses/genericInternalError"
           }
         }
       }
@@ -154,6 +132,45 @@
           "description": "error description"
         }
       }
+    }
+  },
+  "responses": {
+    "genericValidationError": {
+      "description": "Bad request if you send invalid parameters.",
+      "examples": {
+        "application/json": {
+          "success": false,
+          "errorCode": 0,
+          "errorMsg": "At least one mandatory parameter was required but found missing in your request",
+          "version": "3.1.0"
+        }
+      },
+      "schema": {
+        "$ref": "#/definitions/errorModel"
+      }
+    },
+    "genericAuthenticationError": {
+      "description": "Not authenticated"
+    },
+    "genericAuthorizationError": {
+      "description": "User isn't authorized to access to this functionality"
+    },
+    "executionNotFoundError": {
+      "description": "Delivery can't be found",
+      "examples": {
+        "application/json": {
+          "success": false,
+          "errorCode": 0,
+          "errorMsg": "Delivery Execution not found",
+          "version": "3.1.0"
+        }
+      },
+      "schema": {
+        "$ref": "#/definitions/errorModel"
+      }
+    },
+    "genericInternalError": {
+      "description": "Internal error (should not occur)"
     }
   },
   "externalDocs": {

--- a/doc/rest.json
+++ b/doc/rest.json
@@ -99,6 +99,73 @@
           }
         }
       }
+    },
+    "/DeliveryState": {
+      "put": {
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "executions"
+        ],
+        "parameters": [
+          {
+            "name": "uri",
+            "in": "query",
+            "description": "Execution identifier, in URI format",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "state",
+            "in": "body",
+            "description": "State to set the execution to",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "value"
+              ],
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "enum": [
+                    "http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusActive",
+                    "http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusPaused",
+                    "http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusFinished"
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "type": "array"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/genericValidationError"
+          },
+          "401": {
+            "$ref": "#/responses/genericAuthenticationError"
+          },
+          "403": {
+            "$ref": "#/responses/genericAuthorizationError"
+          },
+          "404": {
+            "$ref": "#/responses/executionNotFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/genericInternalError"
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/doc/rest.json
+++ b/doc/rest.json
@@ -100,7 +100,7 @@
         }
       }
     },
-    "/DeliveryState": {
+    "/DeliveryExecutionState": {
       "put": {
         "produces": [
           "application/json"

--- a/doc/rest.json
+++ b/doc/rest.json
@@ -146,7 +146,10 @@
           "200": {
             "description": "Successful response",
             "schema": {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "400": {

--- a/doc/rest.json
+++ b/doc/rest.json
@@ -4,14 +4,25 @@
     "version": "1.0.0",
     "title": ""
   },
+  "securityDefinitions": {
+    "basicAuth": {
+      "type": "basic"
+    }
+  },
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
   "tags": [
     {
       "name": "taoDelivery",
       "description": "Operations about delivery executions"
     }
   ],
+  "basePath": "/taoDelivery",
   "paths": {
-    "/taoDelivery/RestExecution/unstop": {
+    "/RestExecution/unstop": {
       "post": {
         "produces": [
           "application/json"
@@ -92,7 +103,7 @@
             "description": "User isn't authorized to access to this functionality"
           },
           "404": {
-            "description": "Item can't be found",
+            "description": "Delivery can't be found",
             "examples": {
               "application/json": {
                 "success": false,

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.11.0',
+    'version' => '14.12.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -32,18 +32,24 @@ use oat\oatbox\service\exception\InvalidServiceManagerException;
 use oat\oatbox\service\ServiceNotFoundException;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\accessControl\func\AclProxy;
+use oat\tao\model\entryPoint\EntryPointService;
 use oat\tao\model\mvc\DefaultUrlService;
 use oat\tao\model\TaoOntology;
 use oat\tao\model\user\TaoRoles;
 use oat\tao\model\webhooks\WebhookEventsServiceInterface;
 use oat\tao\scripts\update\OntologyUpdater;
-use oat\tao\model\entryPoint\EntryPointService;
+use oat\taoDelivery\controller\DeliveryServer;
 use oat\taoDelivery\controller\RestExecution;
 use oat\taoDelivery\model\AttemptService;
 use oat\taoDelivery\model\AttemptServiceInterface;
 use oat\taoDelivery\model\authorization\AuthorizationService;
 use oat\taoDelivery\model\authorization\strategy\AuthorizationAggregator;
 use oat\taoDelivery\model\authorization\strategy\StateValidation;
+use oat\taoDelivery\model\Capacity\CapacityInterface;
+use oat\taoDelivery\model\Capacity\DummyCapacityService;
+use oat\taoDelivery\model\container\delivery\DeliveryContainerRegistry;
+use oat\taoDelivery\model\container\delivery\DeliveryServiceContainer;
+use oat\taoDelivery\model\container\LegacyRuntime;
 use oat\taoDelivery\model\entrypoint\FrontOfficeEntryPoint;
 use oat\taoDelivery\model\entrypoint\GuestAccess;
 use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteService;
@@ -51,19 +57,13 @@ use oat\taoDelivery\model\execution\DeliveryServerService;
 use oat\taoDelivery\model\execution\implementation\KeyValueService;
 use oat\taoDelivery\model\execution\OntologyService;
 use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoDelivery\model\execution\StateService;
+use oat\taoDelivery\model\fields\DeliveryFieldsService;
+use oat\taoDelivery\model\RuntimeService;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoDelivery\models\classes\ReturnUrlService;
-use oat\taoDelivery\model\fields\DeliveryFieldsService;
-use oat\taoDelivery\model\execution\StateService;
-use oat\taoDelivery\controller\DeliveryServer;
-use oat\taoDelivery\model\RuntimeService;
-use oat\taoDelivery\model\container\LegacyRuntime;
-use oat\taoDelivery\model\container\delivery\DeliveryContainerRegistry;
-use oat\taoDelivery\model\container\delivery\DeliveryServiceContainer;
 use oat\taoDelivery\scripts\install\GenerateRdsDeliveryExecutionTable;
 use oat\taoResultServer\models\classes\ResultServerService;
-use oat\taoDelivery\model\Capacity\CapacityInterface;
-use oat\taoDelivery\model\Capacity\DummyCapacityService;
 
 /**
  * @author Joel Bout <joel@taotesting.com>
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.11.0');
+        $this->skip('14.3.0', '14.12.0');
     }
 }


### PR DESCRIPTION
- [REF-73](https://oat-sa.atlassian.net/browse/REF-73) fix(readme): add a text to the Open API documentation link
- [REF-73](https://oat-sa.atlassian.net/browse/REF-73) fix(api-specification): add authentication specification
- [REF-73](https://oat-sa.atlassian.net/browse/REF-73) chore(api-specification): extract responses
- [REF-73](https://oat-sa.atlassian.net/browse/REF-73) chore(api-specification): add `PUT /DeliveryState` specification
- [REF-73](https://oat-sa.atlassian.net/browse/REF-73) feat(delivery-execution): implement PUT `DeliveryState` request handler
 - [REF-73](https://oat-sa.atlassian.net/browse/REF-73) chore(version): bump a minor one

[The endpoint's documentation](https://openapi.taotesting.com/viewer#/?url=https://github.com/oat-sa/extension-tao-delivery/blob/feature/REF-73/delivery-execution-state-controller/doc/rest.json).

[Backport](https://github.com/oat-sa/extension-tao-delivery/pull/456).