### PR TITLE
REF-58: Allow reactivating execution from more states

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.12.0',
+    'version' => '14.13.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/model/execution/AbstractStateService.php
+++ b/model/execution/AbstractStateService.php
@@ -39,6 +39,12 @@ abstract class AbstractStateService extends ConfigurableService implements State
 {
     use LoggerAwareTrait;
 
+    public const OPTION_REACTIVABLE_STATES = 'reactivableStates';
+
+    private const DEFAULT_REACTIVABLE_STATES = [
+        DeliveryExecution::STATE_TERMINATED,
+    ];
+
     /**
      * Legacy function to ensure all calls to setState use
      * the correct transition instead
@@ -117,7 +123,7 @@ abstract class AbstractStateService extends ConfigurableService implements State
         $executionState = $deliveryExecution->getState()->getUri();
         $result = false;
 
-        if (DeliveryExecution::STATE_TERMINATED === $executionState) {
+        if (in_array($executionState, $this->getReactivableStates(), true)) {
             $user = \common_session_SessionManager::getSession()->getUser();
             /** @var EventManager $eventManager */
             $this->setState($deliveryExecution, DeliveryExecution::STATE_PAUSED);
@@ -127,5 +133,14 @@ abstract class AbstractStateService extends ConfigurableService implements State
         }
 
         return $result;
+    }
+
+    private function getReactivableStates(): array
+    {
+        if (!$this->hasOption(self::OPTION_REACTIVABLE_STATES)) {
+            return self::DEFAULT_REACTIVABLE_STATES;
+        }
+
+        return $this->getOption(self::OPTION_REACTIVABLE_STATES);
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.12.0');
+        $this->skip('14.3.0', '14.13.0');
     }
 }


### PR DESCRIPTION
- [REF-58](https://oat-sa.atlassian.net/browse/REF-58) feat: allow reactivating a delivery execution from more statesby introducing an `AbstractStateService::OPTION_REACTIVABLE_STATES` option
- [REF-58](https://oat-sa.atlassian.net/browse/REF-58) chore(version): bump a minor one

[Backport](https://github.com/oat-sa/extension-tao-delivery/pull/458).