### PR TITLE
Backport REF-58: Allow reactivating execution from more states

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.1.1.1',
+    'version' => '14.1.1.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'tao' => '>=38.9.0',

--- a/model/execution/AbstractStateService.php
+++ b/model/execution/AbstractStateService.php
@@ -38,6 +38,12 @@ abstract class AbstractStateService extends ConfigurableService implements State
 {
     use LoggerAwareTrait;
 
+    public const OPTION_REACTIVABLE_STATES = 'reactivableStates';
+
+    private const DEFAULT_REACTIVABLE_STATES = [
+        DeliveryExecution::STATE_TERMINATED,
+    ];
+
     /**
      * Legacy function to ensure all calls to setState use
      * the correct transition instead
@@ -116,7 +122,7 @@ abstract class AbstractStateService extends ConfigurableService implements State
         $executionState = $deliveryExecution->getState()->getUri();
         $result = false;
 
-        if (DeliveryExecution::STATE_TERMINATED === $executionState) {
+        if (in_array($executionState, $this->getReactivableStates(), true)) {
             $user = \common_session_SessionManager::getSession()->getUser();
             /** @var EventManager $eventManager */
             $this->setState($deliveryExecution, DeliveryExecution::STATE_PAUSED);
@@ -126,5 +132,14 @@ abstract class AbstractStateService extends ConfigurableService implements State
         }
 
         return $result;
+    }
+
+    private function getReactivableStates(): array
+    {
+        if (!$this->hasOption(self::OPTION_REACTIVABLE_STATES)) {
+            return self::DEFAULT_REACTIVABLE_STATES;
+        }
+
+        return $this->getOption(self::OPTION_REACTIVABLE_STATES);
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -436,6 +436,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.0.0');
         }
 
-        $this->skip('14.0.0', '14.1.1.1');
+        $this->skip('14.0.0', '14.1.1.2');
     }
 }


### PR DESCRIPTION
Backports #457.

Required by [`taoNfer`](https://github.com/oat-sa/extension-tao-nfer/pull/192).