### PR TITLE
REF-73: Fix delivery execution state controller's request validation

### DIFF
--- a/controller/DeliveryExecutionState.php
+++ b/controller/DeliveryExecutionState.php
@@ -25,16 +25,37 @@ namespace oat\taoDelivery\controller;
 
 use common_exception_MissingParameter;
 use common_exception_NotFound as NotFoundException;
+use common_exception_NotImplemented as NotImplementedException;
 use common_exception_RestApi as ApiException;
 use oat\taoDelivery\model\execution\Service;
 use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoDelivery\model\execution\StateServiceInterface;
-use tao_actions_CommonRestModule as RestModule;
+use tao_actions_RestController as RestController;
 
 /** Kindly use `funcAcl` in order to assign the roles, having access to the controller */
-class DeliveryExecutionState extends RestModule
+class DeliveryExecutionState extends RestController
 {
-    public function put($uri): void
+    /**
+     * @throws NotFoundException
+     *
+     * @throws NotImplementedException
+     * @throws NotFoundException
+     */
+    public function index(): void
+    {
+        $queryParams = $this->getPsrRequest()->getQueryParams();
+
+        switch ($this->getPsrRequest()->getMethod()) {
+            case 'PUT':
+                $this->put($queryParams['uri'] ?? '');
+                break;
+            default:
+                /** @noinspection PhpUnhandledExceptionInspection */
+                $this->returnFailure(new ApiException('Not implemented'));
+        }
+    }
+
+    private function put(string $uri): void
     {
         if (empty($uri)) {
             $this->returnFailure(new common_exception_MissingParameter('uri'));
@@ -49,25 +70,10 @@ class DeliveryExecutionState extends RestModule
                 $deliveryExecution->setState($state);
             }
         } catch (NotFoundException $exception) {
-            throw new NotFoundException('Delivery execution not found', 404, $exception);
+            $this->returnFailure(new NotFoundException('Delivery execution not found', 404, $exception));
         }
 
         $this->returnSuccess([], false);
-    }
-
-    public function get($uri = null)
-    {
-        $this->returnFailure(new ApiException('Not implemented'));
-    }
-
-    public function post($uri = null)
-    {
-        $this->returnFailure(new ApiException('Not implemented'));
-    }
-
-    public function delete($uri = null)
-    {
-        $this->returnFailure(new ApiException('Not implemented'));
     }
 
     protected function getExecutionService(): Service

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.13.0',
+    'version' => '14.13.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.13.0');
+        $this->skip('14.3.0', '14.13.1');
     }
 }


### PR DESCRIPTION
- [REF-73](https://oat-sa.atlassian.net/browse/REF-73) fix: allow delivery execution ID to be in any format when handling `DeliveryExecutionState` requests
- [REF-73](https://oat-sa.atlassian.net/browse/REF-73) chore(version): bump a fix one

Backport: #460.