### PR TITLE
Made title of the layout configurable

### DIFF
--- a/views/templates/DeliveryServer/layout.tpl
+++ b/views/templates/DeliveryServer/layout.tpl
@@ -12,7 +12,7 @@ use oat\tao\model\theme\Theme;
 
         <?= Layout::renderThemeTemplate(Theme::CONTEXT_FRONTOFFICE, 'head') ?>
 
-        <title><?= __("TAO - An Open and Versatile Computer-Based Assessment Platform") ?></title>
+        <title><?= has_data('title') ? get_data('title') : __("TAO - An Open and Versatile Computer-Based Assessment Platform") ?></title>
 
         <link rel="stylesheet" href="<?= Template::css('tao-main-style.css', 'tao')?>"/>
         <link rel="stylesheet" href="<?= Template::css('tao-3.css', 'tao')?>"/>


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/TCA-341
 
Try to get `title` parameter in the template (Make it not static)

#### How to test

We can add the data parameter definition to any controller that use this template
`$this->setData('title', 'new title');`
  
#### Dependencies
Companion PR :
 - [ ] https://github.com/oat-sa/tao-core/pull/2488
 - [ ] https://github.com/oat-sa/extension-tao-proctoring/pull/807