### PR TITLE
DeliveryServer layout title should be configurable

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -136,6 +136,7 @@ class DeliveryServer extends \tao_actions_CommonModule
         $this->setData('additional-header', $loaderRenderer);
         $this->setData('content-template', 'DeliveryServer/index.tpl');
         $this->setData('content-extension', 'taoDelivery');
+        $this->setData('title', __('TAO: Test Selection'));
         $this->setView('DeliveryServer/layout.tpl', 'taoDelivery');
     }
 
@@ -276,6 +277,7 @@ class DeliveryServer extends \tao_actions_CommonModule
          */
         $this->setData('content-template', 'DeliveryServer/runDeliveryExecution.tpl');
         $this->setData('content-extension', 'taoDelivery');
+        $this->setData('title', __('TAO: %s', $delivery->getLabel()));
         $this->setView('DeliveryServer/layout.tpl', 'taoDelivery');
     }
 

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.13.1',
+    'version' => '14.14.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.13.1');
+        $this->skip('14.3.0', '14.14.0');
     }
 }

--- a/views/templates/DeliveryServer/layout.tpl
+++ b/views/templates/DeliveryServer/layout.tpl
@@ -12,7 +12,7 @@ use oat\tao\model\theme\Theme;
 
         <?= Layout::renderThemeTemplate(Theme::CONTEXT_FRONTOFFICE, 'head') ?>
 
-        <title><?= __("TAO - An Open and Versatile Computer-Based Assessment Platform") ?></title>
+        <title><?= Layout::getTitle() ?></title>
 
         <link rel="stylesheet" href="<?= Template::css('tao-main-style.css', 'tao')?>"/>
         <link rel="stylesheet" href="<?= Template::css('tao-3.css', 'tao')?>"/>


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/TCA-341
 
Layout title should be set from Layout service
 
#### How to test
 
Check pages:
	• delivery index: TAO: Test Selection
	• delivery execution: TAO: <_Name of Test_>

#### Dependencies

Companion PR:
- [ ] https://github.com/oat-sa/extension-tao-proctoring/pull/808