### PR TITLE
Fix REF-78: Resume delivery execution by putting state

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.14.0',
+    'version' => '14.14.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/model/execution/AbstractStateService.php
+++ b/model/execution/AbstractStateService.php
@@ -21,14 +21,15 @@
 
 namespace oat\taoDelivery\model\execution;
 
-use oat\taoDelivery\model\execution\DeliveryExecution as BaseDeliveryExecution;
-use oat\oatbox\service\ConfigurableService;
-use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionReactivated;
-use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState as DeliveryExecutionStateEvent;
+use common_session_SessionManager as SessionManager;
+use oat\oatbox\event\Event;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\log\LoggerAwareTrait;
+use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\user\User;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionReactivated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState as DeliveryExecutionStateEvent;
 
 /**
  * Class AbstractStateService
@@ -42,14 +43,19 @@ abstract class AbstractStateService extends ConfigurableService implements State
     public const OPTION_REACTIVABLE_STATES = 'reactivableStates';
 
     private const DEFAULT_REACTIVABLE_STATES = [
-        DeliveryExecution::STATE_TERMINATED,
+        DeliveryExecutionInterface::STATE_TERMINATED,
+    ];
+
+    private const INTERACTIVE_STATES = [
+        DeliveryExecutionInterface::STATE_ACTIVE,
+        DeliveryExecutionInterface::STATE_PAUSED,
     ];
 
     /**
      * Legacy function to ensure all calls to setState use
      * the correct transition instead
      *
-     * @param BaseDeliveryExecution $deliveryExecution
+     * @param DeliveryExecution $deliveryExecution
      * @param string $state
      * @return bool
      */
@@ -74,49 +80,18 @@ abstract class AbstractStateService extends ConfigurableService implements State
         $deliveryExecution = $this->getStorageEngine()->spawnDeliveryExecution($label, $deliveryId, $user->getIdentifier(), $status);
         // trigger event
         $event = new DeliveryExecutionCreated($deliveryExecution, $user);
-        $this->getServiceLocator()->get(EventManager::SERVICE_ID)->trigger($event);
+        $this->getEventManager()->trigger($event);
+
         return $deliveryExecution;
-    }
-
-    /**
-     * @param BaseDeliveryExecution $deliveryExecution
-     * @param string $state
-     * @return bool
-     * @throws \common_exception_NotFound
-     */
-    protected function setState(BaseDeliveryExecution $deliveryExecution, $state)
-    {
-        $prevState = $deliveryExecution->getState();
-        if ($prevState->getUri() === $state) {
-            $this->logWarning('Delivery execution ' . $deliveryExecution->getIdentifier() . ' already in state ' . $state);
-            return false;
-        }
-
-        $result = $deliveryExecution->getImplementation()->setState($state);
-
-        $event = new DeliveryExecutionStateEvent($deliveryExecution, $state, $prevState->getUri());
-        $this->getServiceManager()->get(EventManager::SERVICE_ID)->trigger($event);
-        $this->logDebug("DeliveryExecutionState from " . $prevState->getUri() . " to " . $state . " triggered");
-
-        return $result;
-    }
-
-    /**
-     * @return Service
-     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
-     */
-    protected function getStorageEngine()
-    {
-        return $this->getServiceLocator()->get(self::STORAGE_SERVICE_ID);
     }
 
     /**
      * @param DeliveryExecution $deliveryExecution
      * @param null $reason
+     *
      * @return mixed
-     * @throws \common_exception_Error
+     *
      * @throws \common_exception_NotFound
-     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
      */
     public function reactivateExecution(DeliveryExecution $deliveryExecution, $reason = null)
     {
@@ -124,15 +99,63 @@ abstract class AbstractStateService extends ConfigurableService implements State
         $result = false;
 
         if (in_array($executionState, $this->getReactivableStates(), true)) {
-            $user = \common_session_SessionManager::getSession()->getUser();
-            /** @var EventManager $eventManager */
-            $this->setState($deliveryExecution, DeliveryExecution::STATE_PAUSED);
-            $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
-            $eventManager->trigger(new DeliveryExecutionReactivated($deliveryExecution, $user, $reason));
+            $this->setState($deliveryExecution, DeliveryExecution::STATE_PAUSED, $reason);
             $result = true;
         }
 
         return $result;
+    }
+
+    /**
+     * @param DeliveryExecution $deliveryExecution
+     * @param string            $state
+     * @param string|null       $reason
+     *
+     * @return bool
+     *
+     * @throws \common_exception_NotFound
+     */
+    protected function setState(DeliveryExecution $deliveryExecution, string $state, string $reason = null): bool
+    {
+        $previousState = $deliveryExecution->getState()->getUri();
+        if ($previousState === $state) {
+            $this->logWarning('Delivery execution ' . $deliveryExecution->getIdentifier() . ' already in state ' . $state);
+
+            return false;
+        }
+
+        $result = $deliveryExecution->getImplementation()->setState($state);
+
+        $this->emitEvent(new DeliveryExecutionStateEvent($deliveryExecution, $state, $previousState));
+        $this->logDebug(sprintf('DeliveryExecutionState from %s to %s triggered', $previousState, $state));
+
+        if (!$this->isStateInteractive($previousState) && $this->isStateInteractive($state)) {
+            $this->emitEvent(new DeliveryExecutionReactivated($deliveryExecution, $this->getUser(), $reason));
+        }
+
+        return $result;
+    }
+
+    protected function getUser(): User
+    {
+        return SessionManager::getSession()->getUser();
+    }
+
+    protected function getStorageEngine(): Service
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(self::STORAGE_SERVICE_ID);
+    }
+
+    private function getEventManager(): EventManager
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+    }
+
+    private function emitEvent(Event $event): void
+    {
+        $this->getEventManager()->trigger($event);
     }
 
     private function getReactivableStates(): array
@@ -142,5 +165,10 @@ abstract class AbstractStateService extends ConfigurableService implements State
         }
 
         return $this->getOption(self::OPTION_REACTIVABLE_STATES);
+    }
+
+    private function isStateInteractive(string $state): bool
+    {
+        return in_array($state, self::INTERACTIVE_STATES, true);
     }
 }

--- a/model/execution/StateServiceInterface.php
+++ b/model/execution/StateServiceInterface.php
@@ -21,6 +21,7 @@
 
 namespace oat\taoDelivery\model\execution;
 
+use common_exception_NotFound;
 use oat\oatbox\user\User;
 
 /**
@@ -32,9 +33,9 @@ use oat\oatbox\user\User;
  */
 interface StateServiceInterface
 {
-    const SERVICE_ID = 'taoDelivery/stateService';
+    public const SERVICE_ID = 'taoDelivery/stateService';
 
-    const STORAGE_SERVICE_ID = 'taoDelivery/execution_service';
+    public const STORAGE_SERVICE_ID = 'taoDelivery/execution_service';
 
     /**
      * Spawns a new delivery execution
@@ -55,6 +56,7 @@ interface StateServiceInterface
      * Terminates a delivery execution
      *
      * @param DeliveryExecution $deliveryExecution
+     *
      * @return bool
      */
     public function terminate(DeliveryExecution $deliveryExecution);
@@ -63,8 +65,11 @@ interface StateServiceInterface
 
     /**
      * @param DeliveryExecution $deliveryExecution
-     * @param null $reason
-     * @return mixed
+     * @param string|null       $reason
+     *
+     * @return bool
+     *
+     * @throws common_exception_NotFound
      */
     public function reactivateExecution(DeliveryExecution $deliveryExecution, $reason = null);
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.14.0');
+        $this->skip('14.3.0', '14.14.1');
     }
 }

--- a/test/unit/model/execution/StateServiceTest.php
+++ b/test/unit/model/execution/StateServiceTest.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+namespace oat\taoDelivery\test\unit\model\execution;
+
+use core_kernel_classes_Resource as CoreResource;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\event\Event;
+use oat\oatbox\event\EventManager;
+use oat\oatbox\log\LoggerService;
+use oat\oatbox\user\User;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\model\execution\implementation\KeyValueService;
+use oat\taoDelivery\model\execution\StateService;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionReactivated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use Psr\Log\NullLogger;
+
+class StateServiceTest extends TestCase
+{
+    private const TEST_DELIVERY_ID = 'delivery_id_1';
+
+    /** @var User|MockObject */
+    private $user;
+
+    /** @var KeyValueService|MockObject */
+    private $storage;
+
+    /** @var EventManager|MockObject */
+    private $eventManager;
+
+    /**
+     * @before
+     */
+    public function initializeDependencies(): void
+    {
+        $this->user         = $this->createMock(User::class);
+        $this->storage      = $this->createMock(KeyValueService::class);
+        $this->eventManager = $this->createMock(EventManager::class);
+
+        $this->user
+            ->method('getIdentifier')
+            ->willReturn('user_id_1');
+    }
+
+    public function testDeliveryExecutionCreation(): void
+    {
+        $sut = $this->createSut();
+
+        $label             = 'test';
+        $deliveryExecution = $this->createMock(DeliveryExecutionInterface::class);
+
+        $this->storage
+            ->expects(static::once())
+            ->method('spawnDeliveryExecution')
+            ->with(
+                $label,
+                self::TEST_DELIVERY_ID,
+                $this->user->getIdentifier(),
+                DeliveryExecutionInterface::STATE_ACTIVE
+            )
+            ->willReturn($deliveryExecution);
+
+        $this->expectEvents(new DeliveryExecutionCreated($deliveryExecution, $this->user));
+
+        $this->assertSame(
+            $deliveryExecution,
+            $sut->createDeliveryExecution(self::TEST_DELIVERY_ID, $this->user, $label)
+        );
+    }
+
+    public function testDeliveryExecutionWithCustomInitialStatusCreation(): void
+    {
+        $initialStatus = DeliveryExecutionInterface::STATE_TERMINATED;
+
+        $sut = $this->createOverriddenInitialStatusImplementation($initialStatus);
+
+        $label             = 'test';
+        $deliveryExecution = $this->createMock(DeliveryExecutionInterface::class);
+
+        $this->storage
+            ->expects(static::once())
+            ->method('spawnDeliveryExecution')
+            ->with(
+                $label,
+                self::TEST_DELIVERY_ID,
+                $this->user->getIdentifier(),
+                $initialStatus
+            )
+            ->willReturn($deliveryExecution);
+
+        $this->expectEvents(new DeliveryExecutionCreated($deliveryExecution, $this->user));
+
+        $this->assertSame(
+            $deliveryExecution,
+            $sut->createDeliveryExecution(self::TEST_DELIVERY_ID, $this->user, $label)
+        );
+    }
+
+    public function testReactivateExecution(): void
+    {
+        $state       = DeliveryExecutionInterface::STATE_TERMINATED;
+        $futureState = DeliveryExecutionInterface::STATE_PAUSED;
+
+        $deliveryExecution = $this->createDeliveryExecution($state, $futureState);
+        $reason            = 'test_reason_1';
+
+        $this->expectEvents(
+            new DeliveryExecutionState($deliveryExecution, $futureState, $state),
+            new DeliveryExecutionReactivated($deliveryExecution, $this->user, $reason)
+        );
+
+        $this->assertTrue($this->createSut()->reactivateExecution($deliveryExecution, $reason));
+    }
+
+    public function testFailToReactivateExecution(): void
+    {
+        $state = DeliveryExecutionInterface::STATE_PAUSED;
+
+        $deliveryExecution = $this->createDeliveryExecution($state);
+        $reason            = 'test_reason_1';
+
+        $this->expectEvents();
+
+        $this->assertFalse($this->createSut()->reactivateExecution($deliveryExecution, $reason));
+    }
+
+    public function testRunTerminated(): void
+    {
+        $state       = DeliveryExecutionInterface::STATE_TERMINATED;
+        $futureState = DeliveryExecutionInterface::STATE_ACTIVE;
+
+        $deliveryExecution = $this->createDeliveryExecution($state, $futureState);
+
+        $this->expectEvents(
+            new DeliveryExecutionState($deliveryExecution, $futureState, $state),
+            new DeliveryExecutionReactivated($deliveryExecution, $this->user)
+        );
+
+        $this->assertTrue($this->createSut()->run($deliveryExecution));
+    }
+
+    public function testRunPaused(): void
+    {
+        $state       = DeliveryExecutionInterface::STATE_PAUSED;
+        $futureState = DeliveryExecutionInterface::STATE_ACTIVE;
+
+        $deliveryExecution = $this->createDeliveryExecution($state, $futureState);
+
+        $this->expectEvents(
+            new DeliveryExecutionState($deliveryExecution, $futureState, $state)
+        );
+
+        $this->assertTrue($this->createSut()->run($deliveryExecution));
+    }
+
+    public function testPauseRunning(): void
+    {
+        $state       = DeliveryExecutionInterface::STATE_ACTIVE;
+        $futureState = DeliveryExecutionInterface::STATE_PAUSED;
+
+        $deliveryExecution = $this->createDeliveryExecution($state, $futureState);
+
+        $this->expectEvents(
+            new DeliveryExecutionState($deliveryExecution, $futureState, $state)
+        );
+
+        $this->assertTrue($this->createSut()->pause($deliveryExecution));
+    }
+
+    public function testPauseTerminated(): void
+    {
+        $state       = DeliveryExecutionInterface::STATE_TERMINATED;
+        $futureState = DeliveryExecutionInterface::STATE_PAUSED;
+
+        $deliveryExecution = $this->createDeliveryExecution($state, $futureState);
+
+        $this->expectEvents(
+            new DeliveryExecutionState($deliveryExecution, $futureState, $state),
+            new DeliveryExecutionReactivated($deliveryExecution, $this->user)
+        );
+
+        $this->assertTrue($this->createSut()->pause($deliveryExecution));
+    }
+
+    public function testFinish(): void
+    {
+        $state       = DeliveryExecutionInterface::STATE_ACTIVE;
+        $futureState = DeliveryExecutionInterface::STATE_FINISHED;
+
+        $deliveryExecution = $this->createDeliveryExecution($state, $futureState);
+
+        $this->expectEvents(
+            new DeliveryExecutionState($deliveryExecution, $futureState, $state)
+        );
+
+        $this->assertTrue($this->createSut()->finish($deliveryExecution));
+    }
+
+    public function testTerminate(): void
+    {
+        $state       = DeliveryExecutionInterface::STATE_ACTIVE;
+        $futureState = DeliveryExecutionInterface::STATE_TERMINATED;
+
+        $deliveryExecution = $this->createDeliveryExecution($state, $futureState);
+
+        $this->expectEvents(
+            new DeliveryExecutionState($deliveryExecution, $futureState, $state)
+        );
+
+        $this->assertTrue($this->createSut()->terminate($deliveryExecution));
+    }
+
+    private function createOverriddenInitialStatusImplementation(string $initialStatus): StateService
+    {
+        $stateService = $this->createSut('getInitialStatus');
+
+        $stateService
+            ->method('getInitialStatus')
+            ->with(self::TEST_DELIVERY_ID, $this->user)
+            ->willReturn($initialStatus);
+
+        return $stateService;
+    }
+
+    /**
+     * @param string ...$overriddenMethods
+     *
+     * @return StateService|MockObject
+     */
+    private function createSut(string ...$overriddenMethods): StateService
+    {
+        $overriddenMethods[] = 'getUser';
+
+        $sut = $this->createPartialMock(StateService::class, $overriddenMethods);
+
+        $sut
+            ->method('getUser')
+            ->willReturn($this->user);
+
+        $sut->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    StateService::STORAGE_SERVICE_ID => $this->storage,
+                    EventManager::SERVICE_ID         => $this->eventManager,
+                    LoggerService::SERVICE_ID        => new NullLogger(),
+                ]
+            )
+        );
+
+        return $sut;
+    }
+
+    private function createDeliveryExecution(string $state, string $futureState = null): DeliveryExecution
+    {
+        $deliveryExecution = $this->createMock(DeliveryExecutionInterface::class);
+
+        $stateResource = $this->createStateResource($state);
+
+        $deliveryExecution
+            ->method('getState')
+            ->willReturn($stateResource);
+
+        $deliveryExecution
+            ->expects($futureState ? static::once() : static::never())
+            ->method('setState')
+            ->with($futureState)
+            ->willReturn(true);
+
+        return new DeliveryExecution($deliveryExecution);
+    }
+
+    private function createStateResource(string $state): CoreResource
+    {
+        $resource = $this->createMock(CoreResource::class);
+
+        $resource
+            ->method('getUri')
+            ->willReturn($state);
+
+        return $resource;
+    }
+
+    private function expectEvents(Event ...$events): void
+    {
+        $this->eventManager
+            ->expects(static::exactly(count($events)))
+            ->method('trigger')
+            ->withConsecutive(...$events);
+    }
+}

--- a/test/unit/model/execution/StateServiceTest.php
+++ b/test/unit/model/execution/StateServiceTest.php
@@ -308,6 +308,13 @@ class StateServiceTest extends TestCase
         $this->eventManager
             ->expects(static::exactly(count($events)))
             ->method('trigger')
-            ->withConsecutive(...$events);
+            ->withConsecutive(
+                ...array_map(
+                       static function (Event $event): array {
+                           return [$event];
+                       },
+                       $events
+                   )
+            );
     }
 }


### PR DESCRIPTION
- [REF-78](https://oat-sa.atlassian.net/browse/REF-78) fix: trigger `DeliveryExecutionReactivated` whenever an execution state is being changed from an inactive to an active one in order to fix a user's session state, linked to it

To be backported to Sprint 111.