### PR TITLE
Tdr 22/fix/remove tao qti test dependency

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.14.1',
+    'version' => '14.14.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/model/execution/Delete/DeliveryExecutionDeleteRequest.php
+++ b/model/execution/Delete/DeliveryExecutionDeleteRequest.php
@@ -22,7 +22,6 @@
 namespace oat\taoDelivery\model\execution\Delete;
 
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
-use qtism\runtime\tests\AssessmentTestSession;
 use core_kernel_classes_Resource;
 
 class DeliveryExecutionDeleteRequest
@@ -33,23 +32,17 @@ class DeliveryExecutionDeleteRequest
     /** @var DeliveryExecutionInterface */
     private $deliveryExecution;
 
-    /** @var AssessmentTestSession */
-    private $session;
-
     /**
      * DeliveryExecutionDeleteRequest constructor.
      * @param core_kernel_classes_Resource $deliveryResource
      * @param DeliveryExecutionInterface $deliveryExecution
-     * @param AssessmentTestSession $session
      */
     public function __construct(
         core_kernel_classes_Resource $deliveryResource,
-        DeliveryExecutionInterface $deliveryExecution,
-        AssessmentTestSession $session = null //can  be null in case delivery was cancelled
+        DeliveryExecutionInterface $deliveryExecution
     ) {
         $this->deliveryResource = $deliveryResource;
         $this->deliveryExecution = $deliveryExecution;
-        $this->session = $session;
     }
 
     /**
@@ -58,14 +51,6 @@ class DeliveryExecutionDeleteRequest
     public function getDeliveryExecution()
     {
         return $this->deliveryExecution;
-    }
-
-    /**
-     * @return AssessmentTestSession
-     */
-    public function getSession()
-    {
-        return $this->session;
     }
 
     /**

--- a/model/execution/rds/RdsDeliveryExecutionService.php
+++ b/model/execution/rds/RdsDeliveryExecutionService.php
@@ -20,7 +20,6 @@
 
 namespace oat\taoDelivery\model\execution\rds;
 
-use common_persistence_sql_pdo_mysql_Driver;
 use common_persistence_SqlPersistence;
 use core_kernel_classes_Resource;
 use Doctrine\DBAL\Query\QueryBuilder;
@@ -263,7 +262,6 @@ class RdsDeliveryExecutionService extends ConfigurableService implements Monitor
      */
     private function getQueryBuilder()
     {
-        /**@var common_persistence_sql_pdo_mysql_Driver $driver */
         return $this->getPersistence()->getPlatform()->getQueryBuilder();
     }
 

--- a/scripts/tools/DeleteDeliveryExecution.php
+++ b/scripts/tools/DeleteDeliveryExecution.php
@@ -74,13 +74,11 @@ class DeleteDeliveryExecution extends ScriptAction
 
         $deliveryExecutionIdentifier = $this->getOption('deliveryExecution');
         $deliveryExecution           = $serviceProxy->getDeliveryExecution($deliveryExecutionIdentifier);
-        $session                     = $this->getSession($deliveryExecution);
 
         try {
             $deleteRequest = new DeliveryExecutionDeleteRequest(
                 $deliveryExecution->getDelivery(),
-                $deliveryExecution,
-                $session
+                $deliveryExecution
             );
 
             $deleteDeliveryExecutionService->execute($deleteRequest);
@@ -93,25 +91,6 @@ class DeleteDeliveryExecution extends ScriptAction
         }
 
         return $report;
-    }
-
-    /**
-     * @param $deliveryExecution
-     * @return null|\qtism\runtime\tests\AssessmentTestSession
-     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
-     */
-    protected function getSession($deliveryExecution)
-    {
-        /** @var TestSessionService $testSessionService */
-        $testSessionService = $this->getServiceManager()->get(TestSessionService::SERVICE_ID);
-
-        try {
-            $session =  $testSessionService->getTestSession($deliveryExecution);
-        } catch (\Exception $exception) {
-            $session = null;
-        }
-
-        return $session;
     }
 
     protected function provideUsage()

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.14.1');
+        $this->skip('14.3.0', '14.14.2');
     }
 }


### PR DESCRIPTION
`AssessmentTestSession` class cannot be used in taoDelivery extension.
depends on https://github.com/oat-sa/extension-tao-testqti/pull/1793