### PR TITLE
Fix/tca 427/remove reason type restriction

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.14.2',
+    'version' => '14.14.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/model/execution/AbstractStateService.php
+++ b/model/execution/AbstractStateService.php
@@ -106,13 +106,13 @@ abstract class AbstractStateService extends ConfigurableService implements State
     /**
      * @param DeliveryExecution $deliveryExecution
      * @param string            $state
-     * @param string|null       $reason
+     * @param string|array|null $reason
      *
      * @return bool
      *
      * @throws common_exception_NotFound
      */
-    protected function setState(DeliveryExecution $deliveryExecution, string $state, string $reason = null): bool
+    protected function setState(DeliveryExecution $deliveryExecution, string $state, $reason = null): bool
     {
         $previousState = $deliveryExecution->getState()->getUri();
         if ($previousState === $state) {

--- a/model/execution/StateServiceInterface.php
+++ b/model/execution/StateServiceInterface.php
@@ -65,7 +65,7 @@ interface StateServiceInterface
 
     /**
      * @param DeliveryExecution $deliveryExecution
-     * @param string|null       $reason
+     * @param string|array|null $reason
      *
      * @return bool
      *

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.14.2');
+        $this->skip('14.3.0', '14.14.3');
     }
 }


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TCA-427

**Problem**
Request fails when proctor tries to reactivate terminated test session via UI interface. It happens because `AbstractStateService::setState()` method expects reason as a string (works good for API calls) and from UI form we receive the reason as an array.

**How to test** (requires https://github.com/oat-sa/extension-tao-testqti/pull/1801 for testing)
- start proctored LTI delivery execution (wait for authorization and start the test)
- as a proctor terminate the session
- as a proctor (requires two roles `TeachingAssistant,Administrator`) try to reactivate the session. 

