### PR TITLE
Fix/tca 554/refactor header and footer

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.14.2',
+    'version' => '14.14.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.14.2');
+        $this->skip('14.3.0', '14.14.3');
     }
 }

--- a/views/templates/DeliveryServer/blocks/footer.tpl
+++ b/views/templates/DeliveryServer/blocks/footer.tpl
@@ -2,7 +2,7 @@
 use oat\tao\helpers\Template;
 use oat\tao\helpers\ApplicationHelper;
 ?>
-<footer class="dark-bar">
+<footer aria-label="About" class="dark-bar">
     © 2013 - <?= date('Y') ?> · <span class="tao-version"><?= ApplicationHelper::getVersionName() ?></span> ·
     Open Assessment Technologies S.A.
     · <?= __('All rights reserved.') ?>

--- a/views/templates/DeliveryServer/blocks/footer.tpl
+++ b/views/templates/DeliveryServer/blocks/footer.tpl
@@ -2,7 +2,7 @@
 use oat\tao\helpers\Template;
 use oat\tao\helpers\ApplicationHelper;
 ?>
-<footer aria-label="About" class="dark-bar">
+<footer aria-label="<?=__('About')?>" class="dark-bar">
     © 2013 - <?= date('Y') ?> · <span class="tao-version"><?= ApplicationHelper::getVersionName() ?></span> ·
     Open Assessment Technologies S.A.
     · <?= __('All rights reserved.') ?>

--- a/views/templates/DeliveryServer/blocks/header.tpl
+++ b/views/templates/DeliveryServer/blocks/header.tpl
@@ -4,7 +4,7 @@ use oat\tao\helpers\Template;
 use oat\tao\model\theme\Theme;
 ?>
 <?php Template::inc('blocks/careers.tpl', 'tao'); ?>
-<header role="menubar" class="dark-bar clearfix">
+<header role="menubar" aria-label="Main Menu" class="dark-bar clearfix">
     <?=Layout::renderThemeTemplate(Theme::CONTEXT_FRONTOFFICE, 'header-logo')?>
     <div class="lft title-box"></div>
     <nav role="menu" class="rgt">

--- a/views/templates/DeliveryServer/blocks/header.tpl
+++ b/views/templates/DeliveryServer/blocks/header.tpl
@@ -4,7 +4,7 @@ use oat\tao\helpers\Template;
 use oat\tao\model\theme\Theme;
 ?>
 <?php Template::inc('blocks/careers.tpl', 'tao'); ?>
-<header role="menubar" aria-label="Main Menu" class="dark-bar clearfix">
+<header role="menubar" aria-label="<?=__('Main Menu')?>" class="dark-bar clearfix">
     <?=Layout::renderThemeTemplate(Theme::CONTEXT_FRONTOFFICE, 'header-logo')?>
     <div class="lft title-box"></div>
     <nav role="menu" class="rgt">


### PR DESCRIPTION
#### Related to:
https://oat-sa.atlassian.net/browse/TCA-554
 
"Header" landmark should not have a heading, the footer is currently missing a label.
  
#### How to test

1. Go to Delivery page
2. Check that:
- `<header>` tag has `aria-label=”Main Menu”`
- `<footer>` tag has `aria-label=”About”`

