### PR TITLE
Fix/tca 619/too specific aria label on test selection

### DIFF
--- a/locales/ar-arb/messages.po
+++ b/locales/ar-arb/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/da-DK/messages.po
+++ b/locales/da-DK/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/de-DE/messages.po
+++ b/locales/de-DE/messages.po
@@ -58,10 +58,16 @@ msgstr "Fortsetzen"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Start"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/el-GR/messages.po
+++ b/locales/el-GR/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/en-US/messages.po
+++ b/locales/en-US/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/es-ES/messages.po
+++ b/locales/es-ES/messages.po
@@ -58,10 +58,16 @@ msgstr "Reanudar"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Empezar"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/es-MX/messages.po
+++ b/locales/es-MX/messages.po
@@ -58,10 +58,16 @@ msgstr "Reanudar"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Empezar"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/fi-FI/messages.po
+++ b/locales/fi-FI/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/fr-CA/messages.po
+++ b/locales/fr-CA/messages.po
@@ -58,10 +58,16 @@ msgstr "Continuer"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Commencer"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/fr-FR/messages.po
+++ b/locales/fr-FR/messages.po
@@ -58,10 +58,16 @@ msgstr "Continuer"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Démarrer"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/hu-HU/messages.po
+++ b/locales/hu-HU/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/id-ID/messages.po
+++ b/locales/id-ID/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/is-IS/messages.po
+++ b/locales/is-IS/messages.po
@@ -58,10 +58,16 @@ msgstr "Halda áfram"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Byrja"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/it-IT/messages.po
+++ b/locales/it-IT/messages.po
@@ -58,10 +58,22 @@ msgstr "Riprendi"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Comincia"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/ja-JP/messages.po
+++ b/locales/ja-JP/messages.po
@@ -58,10 +58,16 @@ msgstr "再開"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "開始"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/lb-LU/messages.po
+++ b/locales/lb-LU/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/lt-LT/messages.po
+++ b/locales/lt-LT/messages.po
@@ -58,10 +58,16 @@ msgstr "Tęsti"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Pradėti"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/nl-NL/messages.po
+++ b/locales/nl-NL/messages.po
@@ -58,10 +58,16 @@ msgstr "Hervatten"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "Starten"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/pl-PL/messages.po
+++ b/locales/pl-PL/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/pt-PT/messages.po
+++ b/locales/pt-PT/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/ru-RU/messages.po
+++ b/locales/ru-RU/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/sk-SK/messages.po
+++ b/locales/sk-SK/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/sv-SE/messages.po
+++ b/locales/sv-SE/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/uk-UA/messages.po
+++ b/locales/uk-UA/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/zh-CN/messages.po
+++ b/locales/zh-CN/messages.po
@@ -58,10 +58,16 @@ msgstr "继续"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "开始"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/zh-SG/messages.po
+++ b/locales/zh-SG/messages.po
@@ -58,10 +58,16 @@ msgstr ""
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/locales/zh-TW/messages.po
+++ b/locales/zh-TW/messages.po
@@ -58,10 +58,16 @@ msgstr "繼續"
 msgid "Resume button"
 msgstr ""
 
+msgid "Resume this test"
+msgstr ""
+
 msgid "Start"
 msgstr "開始"
 
 msgid "Start button"
+msgstr ""
+
+msgid "Start this test"
 msgstr ""
 
 msgid "Started at %s"

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.15.0',
+    'version' => '14.14.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.14.3',
+    'version' => '14.14.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.14.4',
+    'version' => '14.14.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.14.4',
+    'version' => '14.15.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.15.0');
+        $this->skip('14.3.0', '14.14.4');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.14.4');
+        $this->skip('14.3.0', '14.14.5');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.14.4');
+        $this->skip('14.3.0', '14.15.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.14.3');
+        $this->skip('14.3.0', '14.14.4');
     }
 }

--- a/views/templates/DeliveryServer/delivery_entry.tpl
+++ b/views/templates/DeliveryServer/delivery_entry.tpl
@@ -5,7 +5,7 @@ $delivery = get_data('delivery');
 <li>
     <a class="block entry-point entry-point-all-deliveries <?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? "" : "disabled"?>"
         data-launch_url="<?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? $delivery[Delivery::LAUNCH_URL] : "#" ?>"
-        tabindex="-1">
+        tabindex="0">
         <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
 
         <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>

--- a/views/templates/DeliveryServer/delivery_entry.tpl
+++ b/views/templates/DeliveryServer/delivery_entry.tpl
@@ -5,7 +5,7 @@ $delivery = get_data('delivery');
 <li>
     <a class="block entry-point entry-point-all-deliveries <?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? "" : "disabled"?>"
         data-launch_url="<?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? $delivery[Delivery::LAUNCH_URL] : "#" ?>"
-        tabindex="0">
+        tabindex="-1">
         <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
 
         <?php foreach ($delivery[Delivery::DESCRIPTION] as $desc) : ?>
@@ -16,7 +16,7 @@ $delivery = get_data('delivery');
                 class="action"
                 tabindex="0"
                 role="button"
-                aria-label="<?= __('Start button')?>. <?= __('To activate press enter') ?>"
+                aria-label="<?= __('Start this test')?>"
             >
                 <span class="icon-play"></span> <?= __('Start') ?>
             </span>

--- a/views/templates/DeliveryServer/index.tpl
+++ b/views/templates/DeliveryServer/index.tpl
@@ -33,7 +33,7 @@ $warningMessage = get_data('warningMessage');
                             <span class="action"
                                   href="<?= $delivery[Delivery::LAUNCH_URL] ?>"
                                   role="button"
-                                  aria-label="<?= __('Resume button')?>. <?= __('To activate press enter') ?>"
+                                  aria-label="<?= __('Resume this test')?>"
                                   tabindex="0">
                                 <span class="icon-continue"></span> <?= __("Resume") ?>
                             </span>


### PR DESCRIPTION
**Related to**
https://oat-sa.atlassian.net/browse/TCA-619

**Description**
Adjustments to support Different ScreenReaders

**How to test**
1. As a test taker go to the tests selection
2. Navigate with TAB over test cards
3. "Start" and "Resume" buttons should be announced as "Start this test", "Resume this test"
