### PR TITLE
Fix/tao 10346/remove unused delivery param

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.15.0',
+    'version' => '14.15.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/model/execution/DeliveryServerService.php
+++ b/model/execution/DeliveryServerService.php
@@ -109,17 +109,15 @@ class DeliveryServerService extends ConfigurableService
     }
 
     /**
-     * @param string $deliveryExecution
-     * @return ResultStorageWrapper
-     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     * @param string $deliveryExecutionId id expectected, but still accepts delivery executions for backward compatibility
      */
-    public function getResultStoreWrapper($deliveryExecutionId)
+    public function getResultStoreWrapper($deliveryExecutionId): ResultStorageWrapper
     {
         if ($deliveryExecutionId instanceof DeliveryExecutionInterface) {
             $deliveryExecutionId = $deliveryExecutionId->getIdentifier();
         }
         /** @var ResultServerService $resultService */
-        $resultService = $this->getServiceManager()->get(ResultServerService::SERVICE_ID);
+        $resultService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);
         return new ResultStorageWrapper($deliveryExecutionId, $resultService->getResultStorage());
     }
 }

--- a/model/execution/DeliveryServerService.php
+++ b/model/execution/DeliveryServerService.php
@@ -109,19 +109,17 @@ class DeliveryServerService extends ConfigurableService
     }
 
     /**
-     * @param $deliveryExecution
+     * @param string $deliveryExecution
      * @return ResultStorageWrapper
      * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
      */
-    public function getResultStoreWrapper($deliveryExecution)
+    public function getResultStoreWrapper($deliveryExecutionId)
     {
-        //@todo check if cache should be used here
-        if (!$deliveryExecution instanceof DeliveryExecutionInterface) {
-            $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($deliveryExecution);
+        if ($deliveryExecutionId instanceof DeliveryExecutionInterface) {
+            $deliveryExecutionId = $deliveryExecutionId->getIdentifier();
         }
-        $compiledDelivery = $deliveryExecution->getDelivery();
         /** @var ResultServerService $resultService */
         $resultService = $this->getServiceManager()->get(ResultServerService::SERVICE_ID);
-        return new ResultStorageWrapper($deliveryExecution->getIdentifier(), $resultService->getResultStorage($compiledDelivery->getUri()));
+        return new ResultStorageWrapper($deliveryExecutionId, $resultService->getResultStorage());
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.15.0');
+        $this->skip('14.3.0', '14.15.1');
     }
 }


### PR DESCRIPTION
getResultStorage() does not require a parameter so no use in retrieving delivery execution