### PR TITLE
[TCA-680] Test card / Start button are not defined for SRs as "unavailable" or "dimmed" for expired tests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.17.0',
+    'version' => '14.17.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=44.0.0',

--- a/views/templates/DeliveryServer/delivery_entry.tpl
+++ b/views/templates/DeliveryServer/delivery_entry.tpl
@@ -17,6 +17,9 @@ $delivery = get_data('delivery');
                 tabindex="0"
                 role="button"
                 aria-label="<?= __('Start this test')?>"
+                <?php if (!$delivery["TAO_DELIVERY_TAKABLE"]): ?>
+                    aria-disabled="true"
+                <?php endif; ?>
             >
                 <span class="icon-play"></span> <?= __('Start') ?>
             </span>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-680
 
add `aria-disabled` for disabled deliveries
  
#### How to test
 
- prepare an instance of TAO
- prepare an expired delivery
- navigate to delivery index page
- enable screen reader and make sure that it announce outdated delivery as disabled