### PR TITLE
Fix/tca 620 button link announcement

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.15.0',
+    'version' => '14.15.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=41.10.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -444,6 +444,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('14.3.0');
         }
 
-        $this->skip('14.3.0', '14.15.0');
+        $this->skip('14.3.0', '14.15.1');
     }
 }

--- a/views/js/controller/DeliveryServer/index.js
+++ b/views/js/controller/DeliveryServer/index.js
@@ -122,8 +122,8 @@ define([
                     runDelivery($elt.data().launch_url);
                 }
             };
-            $('a.entry-point').on('click', launchDelivery);
-            $('a.entry-point').on('keyup', (e) => {
+            $('.entry-point').on('click', launchDelivery);
+            $('.entry-point').on('keyup', (e) => {
                 if(accessibilityLaunchKeyCodes.includes(e.which)) {
                     launchDelivery(e);
                 }

--- a/views/templates/DeliveryServer/delivery_entry.tpl
+++ b/views/templates/DeliveryServer/delivery_entry.tpl
@@ -3,7 +3,7 @@ use oat\taoDelivery\helper\Delivery;
 $delivery = get_data('delivery');
 ?>
 <li>
-    <a class="block entry-point entry-point-all-deliveries <?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? "" : "disabled"?>"
+    <div class="block entry-point entry-point-all-deliveries <?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? "" : "disabled"?>"
         data-launch_url="<?= ($delivery["TAO_DELIVERY_TAKABLE"]) ? $delivery[Delivery::LAUNCH_URL] : "#" ?>"
         tabindex="-1">
         <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
@@ -21,5 +21,5 @@ $delivery = get_data('delivery');
                 <span class="icon-play"></span> <?= __('Start') ?>
             </span>
         </div>
-    </a>
+    </div>
 </li>

--- a/views/templates/DeliveryServer/index.tpl
+++ b/views/templates/DeliveryServer/index.tpl
@@ -20,7 +20,7 @@ $warningMessage = get_data('warningMessage');
         <ul class="entry-point-box plain">
             <?php foreach ($resumableDeliveries as $delivery): ?>
                 <li>
-                    <a class="block entry-point entry-point-started-deliveries"
+                    <div class="block entry-point entry-point-started-deliveries"
                        data-launch_url="<?= $delivery[Delivery::LAUNCH_URL] ?>"
                        tabindex="-1">
                         <h3><?= _dh($delivery[Delivery::LABEL]) ?></h3>
@@ -38,7 +38,7 @@ $warningMessage = get_data('warningMessage');
                                 <span class="icon-continue"></span> <?= __("Resume") ?>
                             </span>
                         </div>
-                    </a>
+                    </div>
                 </li>
             <?php endforeach; ?>
         </ul>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-620
 
test cards announced twice: as link and as button
 
#### How to test
 
- prepare an instance of TAO
- prepare an any delivery 
- open deliveries list and navigate via keyboard to listen SR announces
- ensure test cards not announced as links
   
Companion PR :
 - [ ] https://github.com/oat-sa/tao-core/pull/2573