### PR TITLE
Fix BSA-192 stop using deprecated execution service interface

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,14 +31,14 @@ use oat\taoDelivery\scripts\install\RegisterWebhookEvents;
 use oat\taoDelivery\scripts\install\RegisterFrontOfficeEntryPoint;
 use oat\taoDelivery\controller\RestExecution;
 
-$extpath = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+$extpath = __DIR__ . DIRECTORY_SEPARATOR;
 
 return [
     'name' => 'taoDelivery',
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.18.0',
+    'version' => '14.18.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=44.0.0',

--- a/model/execution/OntologyService.php
+++ b/model/execution/OntologyService.php
@@ -40,7 +40,7 @@ class OntologyService extends ConfigurableService implements DeliveryExecutionSe
 
     /**
      * (non-PHPdoc)
-     * @see Service::getExecutionsByDelivery()
+     * @see Monitoring::getExecutionsByDelivery()
      * @param core_kernel_classes_Resource $compiled
      * @return DeliveryExecution[]
      */
@@ -58,7 +58,7 @@ class OntologyService extends ConfigurableService implements DeliveryExecutionSe
         }
         return $returnValue;
     }
-    
+
     public function getDeliveryExecutionsByStatus($userUri, $status)
     {
         $executionClass = new core_kernel_classes_Class(OntologyDeliveryExecution::CLASS_URI);
@@ -74,10 +74,10 @@ class OntologyService extends ConfigurableService implements DeliveryExecutionSe
         }
         return $returnValue;
     }
-    
+
     /**
      * (non-PHPdoc)
-     * @see Service::getUserExecutions()
+     * @see DeliveryExecutionService::getUserExecutions()
      */
     public function getUserExecutions(core_kernel_classes_Resource $compiled, $userUri)
     {
@@ -98,7 +98,7 @@ class OntologyService extends ConfigurableService implements DeliveryExecutionSe
     /**
      * @deprecated
      * (non-PHPdoc)
-     * @see Service::initDeliveryExecution()
+     * @see DeliveryExecutionService::initDeliveryExecution()
      */
     public function initDeliveryExecution(core_kernel_classes_Resource $assembly, $userUri)
     {
@@ -132,10 +132,10 @@ class OntologyService extends ConfigurableService implements DeliveryExecutionSe
         ]);
         return $this->getDeliveryExecution($execution);
     }
-    
+
     /**
      * (non-PHPdoc)
-     * @see Service::getDeliveryExecution()
+     * @see DeliveryExecutionService::getDeliveryExecution()
      */
     public function getDeliveryExecution($identifier)
     {

--- a/model/execution/ServiceProxy.php
+++ b/model/execution/ServiceProxy.php
@@ -21,7 +21,6 @@
 
 namespace oat\taoDelivery\model\execution;
 
-use common_exception_Error;
 use common_exception_NoImplementation;
 use common_exception_NotFound;
 use common_Logger;
@@ -51,18 +50,15 @@ class ServiceProxy extends tao_models_classes_Service implements DeliveryExecuti
         $this->getServiceLocator()->register(self::SERVICE_ID, $implementation);
     }
 
-    /**
-     * @return Service
-     * @throws common_exception_Error
-     */
     protected function getImplementation(): DeliveryExecutionService
     {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->getServiceLocator()->get(self::SERVICE_ID);
     }
 
     /**
      * (non-PHPdoc)
-     * @see Service::getUserExecutions()
+     * @see DeliveryExecutionService::getUserExecutions()
      */
     public function getUserExecutions(core_kernel_classes_Resource $assembly, $userUri)
     {
@@ -71,35 +67,23 @@ class ServiceProxy extends tao_models_classes_Service implements DeliveryExecuti
 
     /**
      * (non-PHPdoc)
-     * @see Service::getDeliveryExecutionsByStatus()
+     * @see DeliveryExecutionService::getDeliveryExecutionsByStatus()
      */
     public function getDeliveryExecutionsByStatus($userUri, $status)
     {
         return $this->getImplementation()->getDeliveryExecutionsByStatus($userUri, $status);
     }
 
-    /**
-     * (non-PHPdoc)
-     * @see Service::getActiveDeliveryExecutions()
-     */
     public function getActiveDeliveryExecutions($userUri)
     {
         return $this->getDeliveryExecutionsByStatus($userUri, DeliveryExecutionInterface::STATE_ACTIVE);
     }
 
-    /**
-     * (non-PHPdoc)
-     * @see Service::getPausedDeliveryExecutions()
-     */
     public function getPausedDeliveryExecutions($userUri)
     {
         return $this->getDeliveryExecutionsByStatus($userUri, DeliveryExecutionInterface::STATE_PAUSED);
     }
 
-    /**
-     * (non-PHPdoc)
-     * @see Service::getFinishedDeliveryExecutions()
-     */
     public function getFinishedDeliveryExecutions($userUri)
     {
         return $this->getDeliveryExecutionsByStatus($userUri, DeliveryExecutionInterface::STATE_FINISHED);
@@ -108,7 +92,7 @@ class ServiceProxy extends tao_models_classes_Service implements DeliveryExecuti
     /**
      * @deprecated
      * (non-PHPdoc)
-     * @see Service::initDeliveryExecution()
+     * @see DeliveryExecutionService::initDeliveryExecution()
      * @throws \common_exception_Error
      */
     public function initDeliveryExecution(core_kernel_classes_Resource $assembly, $user)
@@ -136,7 +120,7 @@ class ServiceProxy extends tao_models_classes_Service implements DeliveryExecuti
 
     /**
      * (non-PHPdoc)
-     * @see Service::getDeliveryExecution()
+     * @see DeliveryExecutionService::getDeliveryExecution()
      */
     public function getDeliveryExecution($identifier)
     {

--- a/test/integration/model/execution/OntologyServiceTest.php
+++ b/test/integration/model/execution/OntologyServiceTest.php
@@ -21,10 +21,11 @@
 
 namespace oat\taoDelivery\test\integration\model\execution;
 
-require_once dirname(__FILE__) . '/../../../../../tao/includes/raw_start.php';
+require_once __DIR__ . '/../../../../../tao/includes/raw_start.php';
 
 use oat\tao\test\TaoPhpUnitTestRunner;
 use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoDelivery\model\execution\OntologyDeliveryExecution;
 use oat\taoDelivery\model\execution\OntologyService;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
@@ -42,7 +43,7 @@ class OntologyServiceTest extends TaoPhpUnitTestRunner
     {
         $service = new OntologyService();
         $service->setServiceLocator($this->getServiceManagerProphecy());
-        $this->assertInstanceOf('oat\\taoDelivery\\model\\execution\\Service', $service);
+        $this->assertInstanceOf(DeliveryExecutionService::class, $service);
 
         $assembly = new \core_kernel_classes_Resource('fake');
         $deWrapper = $service->spawnDeliveryExecution('DE label', $assembly, 'fakeUser', 'http://uri.com/fake#StartState');

--- a/test/integration/model/execution/ServiceProxyTest.php
+++ b/test/integration/model/execution/ServiceProxyTest.php
@@ -21,11 +21,12 @@
 
 namespace oat\taoDelivery\test\integration\model\execution;
 
-require_once dirname(__FILE__) . '/../../../../../tao/includes/raw_start.php';
+require_once __DIR__ . '/../../../../../tao/includes/raw_start.php';
 
 use common_exception_NoImplementation;
 use oat\tao\test\TaoPhpUnitTestRunner;
 use common_ext_ExtensionsManager;
+use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\oatbox\user\User;
@@ -60,7 +61,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
     public function testSetImplementation()
     {
         $ext = common_ext_ExtensionsManager::singleton()->getExtensionById('taoDelivery');
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
         $service = $serviceProphecy->reveal();
         ServiceProxy::singleton()->setImplementation($service);
 
@@ -73,7 +74,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
      */
     public function testGetUserExecutions()
     {
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
         $resource = $this->prophesize('core_kernel_classes_Resource');
         $res = $resource->reveal();
         $serviceProphecy->getUserExecutions($res, '#UserUri')->willReturn(true);
@@ -91,7 +92,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
      */
     public function testGetDeliveryExecutionsByStatus()
     {
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
         $serviceProphecy->getDeliveryExecutionsByStatus('#UserUri', 'status')->willReturn(true);
         $service = $serviceProphecy->reveal();
         ServiceProxy::singleton()->setImplementation($service);
@@ -105,7 +106,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
      */
     public function testGetActiveDeliveryExecutions()
     {
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
         $serviceProphecy->getDeliveryExecutionsByStatus('#UserUri', DeliveryExecutionInterface::STATE_ACTIVE)->willReturn(true);
         $service = $serviceProphecy->reveal();
         ServiceProxy::singleton()->setImplementation($service);
@@ -119,7 +120,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
      */
     public function testGetPausedDeliveryExecutions()
     {
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
         $serviceProphecy->getDeliveryExecutionsByStatus('#UserUri', DeliveryExecutionInterface::STATE_PAUSED)->willReturn(true);
         $service = $serviceProphecy->reveal();
         ServiceProxy::singleton()->setImplementation($service);
@@ -133,7 +134,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
      */
     public function testGetFinishedDeliveryExecutions()
     {
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
         $serviceProphecy->getDeliveryExecutionsByStatus('#UserUri', DeliveryExecutionInterface::STATE_FINISHED)->willReturn(true);
 
         $service = $serviceProphecy->reveal();
@@ -148,7 +149,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
      */
     public function testInitDeliveryExecution()
     {
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
 
         $deProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\DeliveryExecution');
         $deliveryExecution = $deProphecy->reveal();
@@ -173,7 +174,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
      */
     public function testGetExecution()
     {
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
         $serviceProphecy->getDeliveryExecution('#id')->willReturn(true);
         $service = $serviceProphecy->reveal();
         ServiceProxy::singleton()->setImplementation($service);
@@ -187,7 +188,7 @@ class ServiceProxyTest extends TaoPhpUnitTestRunner
     public function testGetExecutionsByDeliveryException()
     {
         $this->expectException(common_exception_NoImplementation::class);
-        $serviceProphecy = $this->prophesize('oat\\taoDelivery\\model\\execution\\Service');
+        $serviceProphecy = $this->prophesize(DeliveryExecutionService::class);
         $resource = $this->prophesize('core_kernel_classes_Resource');
         $res = $resource->reveal();
         $service = $serviceProphecy->reveal();


### PR DESCRIPTION
- [BSA-192](https://oat-sa.atlassian.net/browse/BSA-192) fix: stop using deprecated `oat\taoDelivery\model\execution\Service`
- [BSA-192](https://oat-sa.atlassian.net/browse/BSA-192) chore(version): bump a fix one