### PR TITLE
Fix/ncc 239/title webpage on browser from test label

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -271,7 +271,7 @@ class DeliveryServer extends \tao_actions_CommonModule
          */
         $this->setData('content-template', 'DeliveryServer/runDeliveryExecution.tpl');
         $this->setData('content-extension', 'taoDelivery');
-        $this->setData('title', $this->getDeliveryFieldsService()->getBrowserPageTitleRunningExecution($delivery));
+        $this->setData('title', $this->getDeliveryFieldsService()->getDeliveryExecutionPageTitle($delivery));
         $this->setView('DeliveryServer/layout.tpl', 'taoDelivery');
     }
 

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -41,11 +41,11 @@ use oat\taoDelivery\model\authorization\AuthorizationProvider;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\DeliveryServerService;
 use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoDelivery\model\fields\DeliveryFieldsService;
 use oat\taoDelivery\models\classes\ReturnUrlService;
 use oat\taoDelivery\model\authorization\UnAuthorizedException;
 use oat\tao\helpers\Template;
 use oat\taoDelivery\model\execution\StateServiceInterface;
-use oat\taoProctoring\model\execution\DeliveryExecutionManagerService;
 
 /**
  * DeliveryServer Controller
@@ -271,7 +271,7 @@ class DeliveryServer extends \tao_actions_CommonModule
          */
         $this->setData('content-template', 'DeliveryServer/runDeliveryExecution.tpl');
         $this->setData('content-extension', 'taoDelivery');
-        $this->setData('title', $this->getDeliveryExecutionManagerService()->getTitle($delivery));
+        $this->setData('title', $this->getDeliveryFieldsService()->getBrowserPageTitleRunningExecution($delivery));
         $this->setView('DeliveryServer/layout.tpl', 'taoDelivery');
     }
 
@@ -418,10 +418,10 @@ class DeliveryServer extends \tao_actions_CommonModule
     }
 
     /**
-     * @return DeliveryExecutionManagerService
+     * @return DeliveryFieldsService
      */
-    protected function getDeliveryExecutionManagerService()
+    protected function getDeliveryFieldsService()
     {
-        return $this->getServiceLocator()->get(DeliveryExecutionManagerService::SERVICE_ID);
+        return $this->getServiceLocator()->get(DeliveryFieldsService::SERVICE_ID);
     }
 }

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -45,6 +45,7 @@ use oat\taoDelivery\models\classes\ReturnUrlService;
 use oat\taoDelivery\model\authorization\UnAuthorizedException;
 use oat\tao\helpers\Template;
 use oat\taoDelivery\model\execution\StateServiceInterface;
+use oat\taoProctoring\model\execution\DeliveryExecutionManagerService;
 
 /**
  * DeliveryServer Controller
@@ -270,7 +271,7 @@ class DeliveryServer extends \tao_actions_CommonModule
          */
         $this->setData('content-template', 'DeliveryServer/runDeliveryExecution.tpl');
         $this->setData('content-extension', 'taoDelivery');
-        $this->setData('title', __('TAO: %s', $delivery->getLabel()));
+        $this->setData('title', $this->getDeliveryExecutionManagerService()->getTitle($delivery));
         $this->setView('DeliveryServer/layout.tpl', 'taoDelivery');
     }
 
@@ -414,5 +415,13 @@ class DeliveryServer extends \tao_actions_CommonModule
     protected function getExecutionService()
     {
         return ServiceProxy::singleton();
+    }
+
+    /**
+     * @return DeliveryExecutionManagerService
+     */
+    protected function getDeliveryExecutionManagerService()
+    {
+        return $this->getServiceLocator()->get(DeliveryExecutionManagerService::SERVICE_ID);
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label' => 'Delivery core extension',
     'description' => 'TAO delivery extension manges the administration of the tests',
     'license' => 'GPL-2.0',
-    'version' => '14.18.1',
+    'version' => '14.18.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=44.0.0',

--- a/model/fields/DeliveryFieldsService.php
+++ b/model/fields/DeliveryFieldsService.php
@@ -66,7 +66,7 @@ class DeliveryFieldsService extends ConfigurableService
      * @param core_kernel_classes_Resource $delivery
      * @return string
      */
-    public function getBrowserPageTitleRunningExecution(core_kernel_classes_Resource $delivery)
+    public function getDeliveryExecutionPageTitle(core_kernel_classes_Resource $delivery)
     {
         return __('TAO: %s', $delivery->getLabel());
     }

--- a/model/fields/DeliveryFieldsService.php
+++ b/model/fields/DeliveryFieldsService.php
@@ -21,6 +21,7 @@ namespace oat\taoDelivery\model\fields;
  *
  */
 
+use core_kernel_classes_Resource;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 
@@ -57,5 +58,16 @@ class DeliveryFieldsService extends ConfigurableService
             }
         }
         return (string) $label;
+    }
+
+    /**
+     * get Title of the Webpage on the Browser Tab when Run delivery Execution
+     *
+     * @param core_kernel_classes_Resource $delivery
+     * @return string
+     */
+    public function getBrowserPageTitleRunningExecution(core_kernel_classes_Resource $delivery)
+    {
+        return __('TAO: %s', $delivery->getLabel());
     }
 }

--- a/test/unit/model/fields/DeliveryFieldsServiceTest.php
+++ b/test/unit/model/fields/DeliveryFieldsServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoDelivery\test\unit\model\execution;
+
+use core_kernel_classes_Resource;
+use oat\generis\test\TestCase;
+use oat\taoDelivery\model\fields\DeliveryFieldsService;
+
+class DeliveryFieldsServiceTest extends TestCase
+{
+
+    public function testGetDeliveryExecutionPageTitle(): void
+    {
+        $deliveryFieldsService = new DeliveryFieldsService();
+
+        $delivery = $this->createMock(core_kernel_classes_Resource::class);
+        $delivery->expects($this->once())->method('getLabel')->willReturn('test label');
+
+        $result = $deliveryFieldsService->getDeliveryExecutionPageTitle($delivery);
+
+        $this->assertEquals($result, 'TAO: test label');
+    }
+
+}


### PR DESCRIPTION
__Related to task:__ https://oat-sa.atlassian.net/browse/NCC-239
__Description:__ Title of the Webpage on the Browser Tab Pulls from Test Label

__How to test:__
Launch test as a test taker by clicking start
Authorize from proctor screen in separate browser
Click proceed
Click agree on the security statement
Start test

__It depends on it__:  https://github.com/oat-sa/extension-tao-nccer-delivery/pull/1127