### PR TITLE
Register and configure counter service by delivery events

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,6 +25,7 @@ use oat\tao\model\user\TaoRoles;
 use oat\taoDelivery\controller\DeliveryServer;
 use oat\taoDelivery\scripts\install\installDeliveryLogout;
 use oat\taoDelivery\scripts\install\installDeliveryFields;
+use oat\taoDelivery\scripts\install\RegisterCounters;
 use oat\taoDelivery\scripts\install\RegisterDeliveryExecutionConfig;
 use oat\taoDelivery\scripts\install\GenerateRdsDeliveryExecutionTable;
 use oat\taoDelivery\scripts\install\RegisterServiceContainer;
@@ -49,6 +50,7 @@ return [
             RegisterServiceContainer::class,
             RegisterWebhookEvents::class,
             RegisterDeliveryExecutionConfig::class,
+            RegisterCounters::class
         ]
     ],
     'update' => 'oat\\taoDelivery\\scripts\\update\\Updater',

--- a/migrations/Version202108081940308613_taoDelivery.php
+++ b/migrations/Version202108081940308613_taoDelivery.php
@@ -28,16 +28,10 @@ final class Version202108081940308613_taoDelivery extends AbstractMigration
 
     /**
      * @param Schema $schema
-     * @throws CounterServiceException
-     * @throws InvalidServiceManagerException
-     * @throws ServiceNotFoundException
-     * @throws common_Exception
      */
     public function up(Schema $schema): void
     {
-        $registerCounters = new RegisterCounters();
-        $this->propagate($registerCounters);
-        $registerCounters([]);
+        $this->propagate(new RegisterCounters)();
     }
 
     /**

--- a/migrations/Version202108081940308613_taoDelivery.php
+++ b/migrations/Version202108081940308613_taoDelivery.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoDelivery\migrations;
+
+use common_Exception;
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\oatbox\service\ServiceNotFoundException;
+use oat\tao\model\counter\CounterService;
+use oat\tao\model\counter\CounterServiceException;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoDelivery\scripts\install\RegisterCounters;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202108081940308613_taoDelivery extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Attach DeliveryExecutionCreated and DeliveryExecutionState Event Counters.';
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws CounterServiceException
+     * @throws InvalidServiceManagerException
+     * @throws ServiceNotFoundException
+     * @throws common_Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $registerCounters = new RegisterCounters();
+        $this->propagate($registerCounters);
+        $registerCounters([]);
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws common_Exception
+     * @throws ServiceNotFoundException
+     * @throws InvalidServiceManagerException
+     * @throws CounterServiceException
+     */
+    public function down(Schema $schema): void
+    {
+        $serviceManager = $this->getServiceManager();
+
+        /** @var CounterService $counterService */
+        $counterService = $serviceManager->get(CounterService::SERVICE_ID);
+
+        $counterService->detach(DeliveryExecutionCreated::class);
+        $counterService->detach(DeliveryExecutionState::class);
+
+        $serviceManager->register(CounterService::SERVICE_ID, $counterService);
+    }
+}

--- a/model/execution/DeliveryExecutionInterface.php
+++ b/model/execution/DeliveryExecutionInterface.php
@@ -26,7 +26,7 @@ use common_exception_NotFound;
 use core_kernel_classes_Resource;
 
 /**
- * New interface for delivery executions
+ * Interface for delivery executions
  *
  * @access public
  * @author Joel Bout, <joel@taotesting.com>
@@ -34,34 +34,47 @@ use core_kernel_classes_Resource;
  */
 interface DeliveryExecutionInterface
 {
+    public const PROPERTY_PREFIX = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatus';
+
     /**
      * Indicates that a test-taker is currently taking a delivery
      * @var string
+     * @value http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusActive
      */
-    const STATE_ACTIVE = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusActive';
+    public const STATE_ACTIVE = self::PROPERTY_PREFIX . 'Active';
 
     /**
      * Indicates that a delivery is in progress, but the test-taker is not actively taking it
      * @var string
+     * @value http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusPaused
      */
-    const STATE_PAUSED = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusPaused';
+    public const STATE_PAUSED = self::PROPERTY_PREFIX . 'Paused';
 
     /**
      * Indicates that a delivery has been finished successfully and the results should be considered
      * @var string
+     * @value http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusFinished
      */
-    const STATE_FINISHED = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusFinished';
-
-    /**
-     * @deprecated
-     */
-    const STATE_FINISHIED = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusFinished';
+    public const STATE_FINISHED = self::PROPERTY_PREFIX . 'Finished';
 
     /**
      * Indicates that a delivery has been terminated and the results might not be valid
      * @var string
+     * @value http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusTerminated
      */
-    const STATE_TERMINATED = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusTerminated';
+    public const STATE_TERMINATED = self::PROPERTY_PREFIX. 'Terminated';
+
+    /**
+     * @deprecated
+     */
+    public const STATE_FINISHIED = self::STATE_FINISHED;
+
+    /** @var string[] List of states in which delivery can be */
+    public const STATES = [
+        self::STATE_ACTIVE,
+        self::STATE_PAUSED,
+        self::STATE_FINISHED,
+    ];
 
     /**
      * Returns the identifier of the delivery execution
@@ -72,7 +85,7 @@ interface DeliveryExecutionInterface
     public function getIdentifier();
 
     /**
-     * Returns a human readable test representation of the delivery execution
+     * Returns a human-readable test representation of the delivery execution
      * Should respect the current user's language
      *
      * @throws common_exception_NotFound

--- a/model/execution/StateService.php
+++ b/model/execution/StateService.php
@@ -106,15 +106,8 @@ class StateService extends AbstractStateService
         return $result;
     }
 
-    /**
-     * @return array
-     */
-    public function getDeliveriesStates()
+    public function getDeliveriesStates(): array
     {
-         return [
-             DeliveryExecution::STATE_FINISHED,
-             DeliveryExecution::STATE_ACTIVE,
-             DeliveryExecution::STATE_PAUSED
-         ];
+         return DeliveryExecutionInterface::STATES;
     }
 }

--- a/models/classes/execution/event/DeliveryExecutionState.php
+++ b/models/classes/execution/event/DeliveryExecutionState.php
@@ -1,92 +1,80 @@
 <?php
-
 /**
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public License
-* as published by the Free Software Foundation; under version 2
-* of the License (non-upgradable).
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*
-* Copyright (c) 2015 (original work) Open Assessment Technologies SA;
-*
-*
-*/
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types = 1);
 
 namespace oat\taoDelivery\models\classes\execution\event;
 
 use oat\oatbox\event\Event;
-use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 
 /**
-* Event should be triggered after changing delivery execution state.
-*
-* @author Aleh Hutnikau <hutnikau@1pt.com>
-*/
+ * Event should be triggered after changing delivery execution state.
+ *
+ * @author Aleh Hutnikau <hutnikau@1pt.com>
+ */
 class DeliveryExecutionState implements Event
 {
-    /**
-     * @var DeliveryExecutionInterface delivery execution instance
-     */
+    /** @var DeliveryExecutionInterface delivery execution instance */
     private $deliveryExecution;
-    /**
-     * @var string state name
-     */
+
+    /** @var string state name */
     private $state;
-    /**
-     * @var string previous state name
-     */
+
+    /** @var string|null previous state name */
     private $prevState;
 
     /**
      * DeliveryExecutionState constructor.
+     *
      * @param DeliveryExecutionInterface $deliveryExecution
-     * @param string $state
-     * @param string $prevState
+     * @param string                     $state
+     * @param string|null                $prevState
      */
-    public function __construct(DeliveryExecutionInterface $deliveryExecution, $state, $prevState = null)
+    public function __construct(DeliveryExecutionInterface $deliveryExecution, string $state, ?string $prevState)
     {
         $this->deliveryExecution = $deliveryExecution;
         $this->state = $state;
         $this->prevState = $prevState;
     }
 
-    /**
-     * @return DeliveryExecutionInterface
-     */
-    public function getDeliveryExecution()
+    public function getDeliveryExecution(): DeliveryExecutionInterface
     {
         return $this->deliveryExecution;
     }
 
-    /**
-     * @return string
-     */
-    public function getState()
+    public function getState(): string
     {
         return $this->state;
     }
 
-    /**
-     * @return null|string
-     */
-    public function getPreviousState()
+    public function getHumanReadableState(): string
+    {
+        return str_replace(DeliveryExecutionInterface::PROPERTY_PREFIX, '', $this->getState());
+    }
+
+    public function getPreviousState(): ?string
     {
         return $this->prevState;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return __CLASS__;
     }

--- a/scripts/install/RegisterCounters.php
+++ b/scripts/install/RegisterCounters.php
@@ -17,13 +17,13 @@ class RegisterCounters extends InstallAction
     public const COUNTER_SHORT_NAME_DELIVERY_EXECUTION_STATE = 'taoDelivery:state';
 
     /**
-     * @param $params
+     * @param array $params
      * @throws common_Exception
      * @throws ServiceNotFoundException
      * @throws InvalidServiceManagerException
      * @throws CounterServiceException
      */
-    public function __invoke($params)
+    public function __invoke($params = [])
     {
         /** @var CounterService $counterService */
         $counterService = $this->getServiceManager()->get(CounterService::SERVICE_ID);

--- a/scripts/install/RegisterCounters.php
+++ b/scripts/install/RegisterCounters.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace oat\taoDelivery\scripts\install;
+
+use common_Exception;
+use oat\oatbox\extension\InstallAction;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\oatbox\service\ServiceNotFoundException;
+use oat\tao\model\counter\CounterService;
+use oat\tao\model\counter\CounterServiceException;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+
+class RegisterCounters extends InstallAction
+{
+    public const COUNTER_SHORT_NAME_DELIVERY_EXECUTION_CREATED = 'taoDelivery:created';
+    public const COUNTER_SHORT_NAME_DELIVERY_EXECUTION_STATE = 'taoDelivery:state';
+
+    /**
+     * @param $params
+     * @throws common_Exception
+     * @throws ServiceNotFoundException
+     * @throws InvalidServiceManagerException
+     * @throws CounterServiceException
+     */
+    public function __invoke($params)
+    {
+        /** @var CounterService $counterService */
+        $counterService = $this->getServiceManager()->get(CounterService::SERVICE_ID);
+
+        // Attach to Delivery Execution Creation Event.
+        $counterService->attach(
+            DeliveryExecutionCreated::class,
+            self::COUNTER_SHORT_NAME_DELIVERY_EXECUTION_CREATED
+        );
+
+        // Attach to Delivery Execution State Event.
+        // The DeliveryExecutionState::getState() method is used to count depending on the
+        // returned value.
+        $counterService->attach(
+            DeliveryExecutionState::class,
+            self::COUNTER_SHORT_NAME_DELIVERY_EXECUTION_STATE,
+            'getState'
+        );
+
+        $this->getServiceManager()->register(CounterService::SERVICE_ID, $counterService);
+    }
+}

--- a/scripts/tools/ResetDeliveryCounters.php
+++ b/scripts/tools/ResetDeliveryCounters.php
@@ -1,0 +1,6 @@
+<?php
+
+// event?
+// select from the list? - from config, interactive
+// or number, after selecting
+


### PR DESCRIPTION
Registers delivery executions events to the counter service.

Todo:

- [ ] create separate script (tool) for resetting counters via crobjob

https://oat-sa.atlassian.net/browse/CGF-445

Depends on https://github.com/oat-sa/tao-core/pull/3101