### PR TITLE
feat: do not send results in dry-run mode

### DIFF
--- a/config/default/deliveryServer.conf.php
+++ b/config/default/deliveryServer.conf.php
@@ -1,8 +1,6 @@
 <?php
 
 use oat\taoDelivery\model\execution\DeliveryServerService;
-use oat\taoDelivery\model\execution\implementation\ResultServerServiceFactory;
 
 return new DeliveryServerService([
-    DeliveryServerService::OPTION_RESULT_SERVER_SERVICE_FACTORY => new ResultServerServiceFactory()
 ]);

--- a/config/default/deliveryServer.conf.php
+++ b/config/default/deliveryServer.conf.php
@@ -3,5 +3,5 @@
 use oat\taoDelivery\model\execution\DeliveryServerService;
 
 return new DeliveryServerService([
-    DeliveryServerService::OPTION_PROVIDERS => []
+    DeliveryServerService::OPTION_MIDDLEWARE => []
 ]);

--- a/config/default/deliveryServer.conf.php
+++ b/config/default/deliveryServer.conf.php
@@ -1,3 +1,7 @@
 <?php
-return new \oat\taoDelivery\model\execution\DeliveryServerService([
+
+use oat\taoDelivery\model\execution\DeliveryServerService;
+
+return new DeliveryServerService([
+    DeliveryServerService::OPTION_PROVIDERS => []
 ]);

--- a/config/default/deliveryServer.conf.php
+++ b/config/default/deliveryServer.conf.php
@@ -1,7 +1,8 @@
 <?php
 
 use oat\taoDelivery\model\execution\DeliveryServerService;
+use oat\taoDelivery\model\execution\implementation\ResultServerServiceFactory;
 
 return new DeliveryServerService([
-    DeliveryServerService::OPTION_MIDDLEWARE => []
+    DeliveryServerService::OPTION_RESULT_SERVER_SERVICE_FACTORY => new ResultServerServiceFactory()
 ]);

--- a/config/default/deliveryServer.conf.php
+++ b/config/default/deliveryServer.conf.php
@@ -1,6 +1,3 @@
 <?php
 
-use oat\taoDelivery\model\execution\DeliveryServerService;
-
-return new DeliveryServerService([
-]);
+return new \oat\taoDelivery\model\execution\DeliveryServerService([]);

--- a/model/execution/DeliveryServerService.php
+++ b/model/execution/DeliveryServerService.php
@@ -46,7 +46,7 @@ class DeliveryServerService extends ConfigurableService
 
     public const SERVICE_ID = 'taoDelivery/deliveryServer';
 
-    public const OPTION_PROVIDERS = 'providers';
+    public const OPTION_MIDDLEWARE = 'middleware';
 
     public static function singleton()
     {
@@ -125,34 +125,34 @@ class DeliveryServerService extends ConfigurableService
         return new ResultStorageWrapper($deliveryExecutionId, $resultService->getResultStorage());
     }
 
-    public function addProvider($provider): void
+    public function registerMiddleware($middleware): void
     {
-        $providers = $this->getOption(self::OPTION_PROVIDERS, []);
+        $middlewares = $this->getOption(self::OPTION_MIDDLEWARE, []);
 
-        $providers[] = $provider;
+        $middlewares[] = $middleware;
 
-        $this->setOption(self::OPTION_PROVIDERS, $providers);
+        $this->setOption(self::OPTION_MIDDLEWARE, $middlewares);
     }
 
-    public function removeProvider($providerClass): void
+    public function unregisterMiddleware($class): void
     {
-        $providers = $this->getOption(self::OPTION_PROVIDERS);
+        $middlewares = $this->getOption(self::OPTION_MIDDLEWARE);
 
-        foreach ($providers as $key => $provider) {
-            if (get_class($provider) == $providerClass) {
-                unset($providers[$key]);
+        foreach ($middlewares as $key => $middleware) {
+            if (get_class($middleware) == $class) {
+                unset($middlewares[$key]);
             }
         }
 
-        $this->setOption(self::OPTION_PROVIDERS, $providers);
+        $this->setOption(self::OPTION_MIDDLEWARE, $middlewares);
     }
 
-    private function getProviders(): array
+    private function getMiddlewareList(): array
     {
-        if ($this->hasOption(self::OPTION_PROVIDERS)
-            && is_array($providers = $this->getOption(self::OPTION_PROVIDERS))
+        if ($this->hasOption(self::OPTION_MIDDLEWARE)
+            && is_array($middlewares = $this->getOption(self::OPTION_MIDDLEWARE))
         ) {
-            return $providers;
+            return $middlewares;
         }
 
         return [];
@@ -162,9 +162,9 @@ class DeliveryServerService extends ConfigurableService
     {
         $isDryRun = false;
 
-        foreach ($this->getProviders() as $provider) {
-            if ($provider instanceof DryRunCheckerInterface) {
-                $isDryRun = $provider->isDryRun();
+        foreach ($this->getMiddlewareList() as $middleware) {
+            if ($middleware instanceof DryRunCheckerInterface) {
+                $isDryRun = $middleware->isDryRun();
             }
 
             if ($isDryRun) {

--- a/model/execution/DeliveryServerService.php
+++ b/model/execution/DeliveryServerService.php
@@ -22,6 +22,7 @@
 namespace oat\taoDelivery\model\execution;
 
 use common_Exception;
+use Laminas\ServiceManager\ServiceLocatorAwareInterface;
 use oat\oatbox\user\User;
 use oat\oatbox\service\ServiceManager;
 use oat\oatbox\service\ConfigurableService;
@@ -135,7 +136,9 @@ class DeliveryServerService extends ConfigurableService
         $factory = $this->getOption(self::OPTION_RESULT_SERVER_SERVICE_FACTORY);
 
         if ($factory instanceof ResultServerServiceFactoryInterface) {
-            $this->propagate($factory);
+            if ($factory instanceof ServiceLocatorAwareInterface) {
+                $this->propagate($factory);
+            }
             $this->resultServerService = $factory->create();
         } else {
             $this->resultServerService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);

--- a/model/execution/DeliveryServerService.php
+++ b/model/execution/DeliveryServerService.php
@@ -42,11 +42,11 @@ use oat\taoResultServer\models\classes\implementation\ResultServerService as Res
 class DeliveryServerService extends ConfigurableService
 {
     /** @deprecated */
-    const CONFIG_ID = 'taoDelivery/deliveryServer';
+    public const CONFIG_ID = 'taoDelivery/deliveryServer';
 
-    const SERVICE_ID = 'taoDelivery/deliveryServer';
+    public const SERVICE_ID = 'taoDelivery/deliveryServer';
 
-    const OPTION_PROVIDERS = 'providers';
+    public const OPTION_PROVIDERS = 'providers';
 
     public static function singleton()
     {

--- a/model/execution/DryRunCheckerInterface.php
+++ b/model/execution/DryRunCheckerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDelivery\model\execution;
+
+interface DryRunCheckerInterface
+{
+    public function isDryRun(): bool;
+}

--- a/model/execution/ResultServerServiceFactoryInterface.php
+++ b/model/execution/ResultServerServiceFactoryInterface.php
@@ -23,7 +23,9 @@ declare(strict_types=1);
 
 namespace oat\taoDelivery\model\execution;
 
-interface DryRunCheckerInterface
+use oat\taoResultServer\models\classes\ResultServerService;
+
+interface ResultServerServiceFactoryInterface
 {
-    public function isDryRun(): bool;
+    public function create(): ResultServerService;
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-2715

For local testing:

- launch LTI 1p3 using the following claims

```
{
    "https://purl.imsglobal.org/spec/lti/claim/roles": [
        "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"
    ]
}
```

Test using DEMO DevKit on kitchen env


https://devkit-oat-demo.dev.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=testTeacherRegistration&user_list=c3po&launch_url=https://delivery.test-tr-2715.playground.kitchen.it.taocloud.org/ltiDeliveryProvider/DeliveryTool/launch1p3?delivery%3Dhttp%253A%252F%252Fdelivery.test-tr-2715.playground.kitchen.it.taocloud.org%252Ftao.rdf%2523i6194d5b5e4bc994c08bb2ce86c3503&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Instructor%22%0D%0A%20%20%20%20%5D%0D%0A%7D