### PR TITLE
Fix TR-3537 verify delivery execution state before resuming

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -235,8 +235,6 @@ class DeliveryServer extends \tao_actions_CommonModule
             $this->verifyDeliveryExecutionAuthorized($deliveryExecution);
         } catch (UnAuthorizedException $e) {
             $this->redirect($e->getErrorPage());
-
-            return;
         }
 
         $userUri = common_session_SessionManager::getSession()->getUserUri();

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -104,15 +104,15 @@ class DeliveryServer extends \tao_actions_CommonModule
             $resumableData[] = DeliveryHelper::buildFromDeliveryExecution($de);
         }
         $this->setData('resumableDeliveries', $resumableData);
-        
+
         $assignmentService = $this->getServiceLocator()->get(AssignmentService::SERVICE_ID);
-        
+
         $deliveryData = [];
         foreach ($assignmentService->getAssignments($user) as $delivery) {
             $deliveryData[] = DeliveryHelper::buildFromAssembly($delivery, $user);
         }
         $this->setData('availableDeliveries', $deliveryData);
-                
+
         /**
          * Header & footer info
          */
@@ -130,7 +130,7 @@ class DeliveryServer extends \tao_actions_CommonModule
         /* @var $urlRouteService DefaultUrlService */
         $urlRouteService = $this->getServiceManager()->get(DefaultUrlService::SERVICE_ID);
         $this->setData('logout', $urlRouteService->getUrl('logoutDelivery', []));
-        
+
         /**
          * Layout template + real template inclusion
          */
@@ -160,7 +160,7 @@ class DeliveryServer extends \tao_actions_CommonModule
         }
         return $result;
     }
-    
+
     /**
      * Init a delivery execution from the current delivery.
      *
@@ -323,7 +323,7 @@ class DeliveryServer extends \tao_actions_CommonModule
     {
         $this->getDeliveryServer()->initResultServer($compiledDelivery, $executionIdentifier, $userUri);
     }
-    
+
     /**
      * Defines if the top and bottom action menu should be displayed or not
      *
@@ -348,7 +348,7 @@ class DeliveryServer extends \tao_actions_CommonModule
         }
         return _url('index', 'DeliveryServer', 'taoDelivery');
     }
-    
+
     /**
      * Defines the URL of the finish delivery execution action
      * @param DeliveryExecution $deliveryExecution

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -86,7 +86,6 @@ class DeliveryServer extends \tao_actions_CommonModule
      *
      * @access public
      * @author CRP Henri Tudor - TAO Team - {@link http://www.tao.lu}
-     * @param processDefinitionUri
      * @return void
      * @throws \common_exception_Error
      */

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -222,6 +222,10 @@ class DeliveryServer extends \tao_actions_CommonModule
     {
         $deliveryExecution = $this->getCurrentDeliveryExecution();
 
+        if (!in_array($deliveryExecution->getState()->getUri(), $this->getDeliveryServer()->getResumableStates())) {
+            $this->redirect($this->getReturnUrl());
+        }
+
         // Sets the deliveryId to session.
         if (!$this->hasSessionAttribute(DeliveryExecution::getDeliveryIdSessionKey($deliveryExecution->getIdentifier()))) {
             $this->setSessionAttribute(

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -364,8 +364,7 @@ class DeliveryServer extends \tao_actions_CommonModule
      */
     protected function getAuthorizationProvider()
     {
-        $authService = $this->getServiceLocator()->get(AuthorizationService::SERVICE_ID);
-        return $authService->getAuthorizationProvider();
+        return $this->getServiceLocator()->get(AuthorizationService::SERVICE_ID)->getAuthorizationProvider();
     }
 
     /**


### PR DESCRIPTION
# [TR-3537](https://oat-sa.atlassian.net/browse/TR-3537)

## How to test
1. Have an AI proctoring-enabled organization assignment
2. Launch a delivery execution
3. Complete the delivery execution
4. Stop the screen recording via the Invigulus UI
5. Make sure no error pops up on the screen

https://user-images.githubusercontent.com/2943256/154089792-25d1f9ed-64f2-49ba-8bfc-32614bba204f.mov

## Changelog
- fix(cs): remove extra spaces
- chore: remove unreachable code from `DeliveryServer` controller methods
- fix: remove inexistent param doc from `DeliveryServer::index()` method
- fix(cs): inline `DeliveryServer::getAuthorizationProvider()` method variable
- fix: verify the state of a delivery execution before attempting to resume it

[Backport](https://github.com/oat-sa/extension-tao-delivery/compare/v14.19.0...v14.19.0.1).