### PR TITLE
fix: Don't fetch the current session and user on AbstractStateService unless needed

### DIFF
--- a/model/execution/AbstractStateService.php
+++ b/model/execution/AbstractStateService.php
@@ -121,7 +121,7 @@ abstract class AbstractStateService extends ConfigurableService implements State
         $previousState = $deliveryExecution->getState()->getUri();
         if ($previousState === $state) {
             $this->logWarning(
-                'Delivery execution ' . $deliveryExecution->getIdentifier() . ' already in state ' . $state
+                "Delivery execution {$deliveryExecution->getIdentifier()} already in state {$state}"
             );
 
             return false;
@@ -129,14 +129,14 @@ abstract class AbstractStateService extends ConfigurableService implements State
 
         $result = $deliveryExecution->getImplementation()->setState($state);
 
-        $user = common_session_SessionManager::getSession()->getUser();
+        $context = null;
 
-        $context =
-            $state === DeliveryExecutionInterface::STATE_FINISHED
-            ? new DeliveryExecutionStateContext([
+        if ($state === DeliveryExecutionInterface::STATE_FINISHED) {
+            $user = common_session_SessionManager::getSession()->getUser();
+            $context = new DeliveryExecutionStateContext([
                 DeliveryExecutionStateContext::PARAM_USER => $user
-            ])
-            : null;
+            ]);
+        }
 
         $this->emitEvent(new DeliveryExecutionStateEvent($deliveryExecution, $state, $previousState, $context));
         $this->logDebug(sprintf('DeliveryExecutionState from %s to %s triggered', $previousState, $state));


### PR DESCRIPTION
**Associated Jira issue:** [RFE-748](https://oat-sa.atlassian.net/browse/RFE-748)

In order to pause a session, we use `StateService::pause()`. That method calls `AbstractStateSeervice::setState()`.

The implementation for that method always fetches the information about the user is taking the test (from the current session) so it can then instantiate a `DeliveryExecutionStateContext` bound to that user that is then used to trigger an event.  However, the user is not needed if the new state is other than `FINISHED` (because in such case the context is then not really used).

On the other hand, if trying to pause a session that is not associated with the current user / session, or if there is no session at all (i.e. in review mode), calls to `common_session_SessionManager::getSession()->getUser()` fail when trying to retrieve the current session (because it may not be a session at all (as in review mode), or it may be bound to a different test, etc), making the pause operation to fail as well (error "No AssessmentItemSesion object bound to 'Q01.0").

Changes in this PR prevent trying to instantiate the session and user unless the next state is FINISHED, which was already the only case in which the user is needed.

**Related PRs:**
- https://github.com/oat-sa/extension-tao-testqti/pull/2419
- https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/362